### PR TITLE
create script that runs validate-migration.sh in CI with Sanitizers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,8 @@ insert_final_newline = unset
 trim_trailing_whitespace = unset
 indent_style = unset
 indent_size = unset
+
+[{*.sh, *.bash}]
+indent_style = space
+indent_size = 2
+switch_case_indent = true

--- a/.github/workflows/run-test.sh
+++ b/.github/workflows/run-test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+SCRIPT_ROOT="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+cd "${SCRIPT_ROOT}/../.."
+
+export TEMPLATES="${SCRIPT_ROOT}/templates"
+
+set -euxo pipefail
+
+export P4USER="${P4USER:-"admin"}"                   # the name of the Perforce superuser that the script will use to create the depot
+export P4PORT="${P4PORT:-"perforce.sgdev.org:1666"}" # the address of the Perforce server to connect to
+
+export DEPOT_NAME="${DEPOT_NAME:-"source/src-cli"}"      # the name of the depot that the script will create on the server
+export P4CLIENT="${P4CLIENT:-"integration-test-client"}" # the name of the temporary client that the script will use while it creates the depot
+
+TMP="$(mktemp -d)"
+export DEPOT_DIR="${TMP}/${DEPOT_NAME}"
+export GIT_DEPOT_DIR="${TMP}/git-${DEPOT_NAME}"
+export P4_FUSION_LOG="${TMP}/p4-fusion.log"
+
+cleanup() {
+  # ensure that we don't leave a client behind (using up one of our licenses)
+  delete_perforce_client
+
+  # delete temp folders
+  rm -rf "${TMP}" || true
+}
+trap cleanup EXIT
+
+# delete_perforce_client deletes the client specified by "$P4CLIENT"
+# if it exists on the Perforce server.
+#
+## P4 CLI reference(s):
+##
+## https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_client.html
+delete_perforce_client() {
+  if p4 clients | awk '{print $2}' | grep -Fxq "${P4CLIENT}"; then
+    # delete the client
+
+    p4 client -f -Fs -d "${P4CLIENT}"
+  fi
+}
+
+# ensure that user is logged into the Perforce server
+if ! p4 login -s &>/dev/null; then
+  handbook_link="https://handbook.sourcegraph.com/departments/ce-support/support/process/p4-enablement/#generate-a-session-ticket"
+  address="${P4USER}:${P4PORT}"
+
+  cat <<END
+'p4 login -s' command failed. This indicates that you might not be logged into '$address'.
+Try using 'p4 -u ${P4USER} login -a' to generate a session ticket.
+See '${handbook_link}' for more information.
+END
+
+  exit 1
+fi
+
+{
+  printf "(re)creating temporary client '%s'..." "$P4CLIENT"
+
+  # delete older copy of client (if it exists)
+  delete_perforce_client
+  envsubst <"${TEMPLATES}/client.tmpl"
+  # create new client
+  P4_CLIENT_HOST="$(hostname)" envsubst <"${TEMPLATES}/client.tmpl" |
+    p4 client -i
+
+  printf "done\n"
+}
+
+# build p4-fusion
+OPENSSL_ROOT_DIR="/opt/homebrew/opt/openssl@1.1/" ./generate_cache.sh Debug
+./build.sh
+
+# run p4-fusion against the downloaded depot
+./build/p4-fusion/p4-fusion \
+  --path "//${DEPOT_NAME}/..." \
+  --client "${P4CLIENT}" \
+  --user "$P4USER" \
+  --src "${GIT_DEPOT_DIR}" \
+  --networkThreads 64 \
+  --port "${P4PORT}" \
+  --lookAhead 15000 \
+  --printBatch 1000 \
+  --noBaseCommit true \
+  --retries 10 \
+  --refresh 1000 \
+  --maxChanges -1 \
+  --includeBinaries true \
+  --fsyncEnable true \
+  --noColor true 2>&1 | tee "${P4_FUSION_LOG}"
+
+# run validation on migrated data
+./validate-migration.sh \
+  --force \
+  --debug \
+  --logfile="${P4_FUSION_LOG}" \
+  --p4workdir="${DEPOT_DIR}" \
+  --gitdir="${GIT_DEPOT_DIR}" \
+  --datadir="${TMP}/datadir"

--- a/.github/workflows/run-test.sh
+++ b/.github/workflows/run-test.sh
@@ -62,14 +62,13 @@ fi
   delete_perforce_client
   envsubst <"${TEMPLATES}/client.tmpl"
   # create new client
-  P4_CLIENT_HOST="$(hostname)" envsubst <"${TEMPLATES}/client.tmpl" |
-    p4 client -i
+  P4_CLIENT_HOST="$(hostname)" envsubst <"${TEMPLATES}/client.tmpl" | p4 client -i
 
   printf "done\n"
 }
 
 # build p4-fusion
-OPENSSL_ROOT_DIR="/opt/homebrew/opt/openssl@1.1/" ./generate_cache.sh Debug
+./generate_cache.sh Debug
 ./build.sh
 
 # run p4-fusion against the downloaded depot

--- a/.github/workflows/run-test.sh
+++ b/.github/workflows/run-test.sh
@@ -60,19 +60,21 @@ fi
 
   # delete older copy of client (if it exists)
   delete_perforce_client
-  envsubst <"${TEMPLATES}/client.tmpl"
   # create new client
   P4_CLIENT_HOST="$(hostname)" envsubst <"${TEMPLATES}/client.tmpl" | p4 client -i
 
   printf "done\n"
 }
 
-# build p4-fusion
-./generate_cache.sh Debug
-./build.sh
+echo "::group::{Build P4 Fusion}"
 
-# run p4-fusion against the downloaded depot
-./build/p4-fusion/p4-fusion \
+time (./generate_cache.sh Debug && ./build.sh)
+
+echo "::endgroup::"
+
+echo "::group::{Run p4-fusion against the downloaded depot}"
+
+time ./build/p4-fusion/p4-fusion \
   --path "//${DEPOT_NAME}/..." \
   --client "${P4CLIENT}" \
   --user "$P4USER" \
@@ -89,11 +91,16 @@ fi
   --fsyncEnable true \
   --noColor true 2>&1 | tee "${P4_FUSION_LOG}"
 
-# run validation on migrated data
-./validate-migration.sh \
+echo "::endgroup::"
+
+echo "::group::{Run validation on migrated data}"
+
+time ./validate-migration.sh \
   --force \
   --debug \
   --logfile="${P4_FUSION_LOG}" \
   --p4workdir="${DEPOT_DIR}" \
   --gitdir="${GIT_DEPOT_DIR}" \
   --datadir="${TMP}/datadir"
+
+echo "::endgroup::"

--- a/.github/workflows/templates/client.tmpl
+++ b/.github/workflows/templates/client.tmpl
@@ -1,0 +1,20 @@
+Client: ${P4CLIENT}
+
+Owner:  ${P4USER}
+
+Host: ${P4_CLIENT_HOST}
+
+Description: ${DEPOT_DESCRIPTION}
+
+Root: ${DEPOT_DIR}
+
+# Note!!! The rmdir option here is very important!
+Options: noallwrite noclobber nocompress unlocked nomodtime rmdir
+
+SubmitOptions:  submitunchanged
+
+LineEnd: local
+
+View:
+        //${DEPOT_NAME}/... //${P4CLIENT}/...
+

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -12,12 +12,37 @@ env:
   P4PORT: "perforce.sgdev.org:1666" # the address of the Perforce server to connect to
   P4USER: "admin" # the name of the Perforce user
   P4PASSWD: ${{ secrets.P4PASSWD }} # the ticket for the Perforce user
-  P4CLIENT: "validate-migration-${{ github.ref_name }}-${{ github.run_number }}" # the temporary Perforce client name to use while validating the git migration
 
   DEPOT_NAME: "source/src-cli" # the name of the Perforce depot to validate the git migration against
 
 jobs:
   validate-migration:
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+          - addressSanitizer
+          - threadSanitizer
+          #          disabled until we figure out how to build with clang in github actions
+          #          - memorySanitizer
+          - leakSanitizer
+          - undefinedSanitizer
+          - noSanitizer
+        include:
+          - sanitizer: addressSanitizer
+            CMAKE_CXX_FLAGS: "-fsanitize=address -g"
+          - sanitizer: threadSanitizer
+            CMAKE_CXX_FLAGS: "-fsanitize=thread -g"
+          #          disabled until we figure out how to build with clang in github actions
+          #          - sanitizer: memorySanitizer
+          #            CMAKE_CXX_FLAGS: "-fsanitize=memory -g"
+          - sanitizer: leakSanitizer
+            CMAKE_CXX_FLAGS: "-fsanitize=leak -g"
+          - sanitizer: undefinedSanitizer
+            CMAKE_CXX_FLAGS: "-fsanitize=undefined -g"
+          - sanitizer: noSanitizer
+            CMAKE_CXX_FLAGS: ""
+
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +57,7 @@ jobs:
       - name: "Install c++ compilation dependencies"
         run: |
           sudo apt-get update
-          sudo apt-get install git make cmake clang --yes # p4-fusion dependencies
+          sudo apt-get install git make cmake gcc g++ clang --yes # p4-fusion dependencies
 
       - name: "Cache Perforce API headers"
         id: cache-p4api
@@ -71,5 +96,6 @@ jobs:
           sudo apt-get install gettext --yes # for envsubst 
           .github/workflows/run-test.sh
         env:
+          P4CLIENT: "validate-migration-${{ github.ref_name }}-${{ github.run_number }}-${{ matrix.sanitizer }}" # the temporary Perforce client name to use while validating the git migration
           OPENSSL_ROOT_DIR: ${{ env.OPENSSL_INSTALL_DIR }}
-          CXX: "clang"
+          CMAKE_CXX_FLAGS: "${{ matrix.CMAKE_CXX_FLAGS }} -O0"

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -1,0 +1,47 @@
+name: validate-migration
+
+on: [ push ]
+
+env:
+  P4PORT: "perforce.sgdev.org:1666"
+  P4USER: "admin"
+  P4PASSWD: ${{ secrets.P4PASSWD }}
+
+jobs:
+  validate-migration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      # install p4 client from Perforce
+      - name: "Install p4-fusion client"
+        uses: perforce/setup-p4@1.0.2
+        with:
+          command: "help"
+          p4_version: 23.1
+
+      - name: "Install dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install gettext --yes # for envsubst 
+          sudo apt-get install git make cmake g++ --yes # p4-fusion dependencies
+          
+          # download p4-fusion headers
+          curl -L https://www.perforce.com/downloads/perforce/r22.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.0.2.tgz --output p4.tgz
+          mkdir -p vendor/helix-core-api/linux
+          tar -C vendor/helix-core-api/linux -xzf p4.tgz --strip 1
+
+          # compile openssl
+          mkdir openssl-src
+          curl -L https://www.openssl.org/source/openssl-1.0.2t.tar.gz --output openssl.tgz
+          tar -C openssl-src -xzf openssl.tgz --strip 1
+          pushd openssl-src
+          ./config --prefix=/tmp/openssl-install
+          make install
+          popd 
+
+
+      - name: "run validate migration script"
+        run: bash .github/workflows/run-test.sh
+        env:
+          OPENSSL_ROOT_DIR: "/tmp/openssl-install"

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -3,9 +3,18 @@ name: validate-migration
 on: [ push ]
 
 env:
-  P4PORT: "perforce.sgdev.org:1666"
-  P4USER: "admin"
-  P4PASSWD: ${{ secrets.P4PASSWD }}
+  # Constants
+  P4_DOWNLOAD_URL: "https://www.perforce.com/downloads/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.0.2.tgz"
+  OPENSSL_DOWNLOAD_URL: "https://www.openssl.org/source/openssl-1.0.2u.tar.gz"
+  OPENSSL_INSTALL_DIR: "/tmp/openssl-install"
+
+  # Perforce credentials
+  P4PORT: "perforce.sgdev.org:1666" # the address of the Perforce server to connect to
+  P4USER: "admin" # the name of the Perforce user
+  P4PASSWD: ${{ secrets.P4PASSWD }} # the ticket for the Perforce user
+  P4CLIENT: "validate-migration-${{ github.ref_name }}-${{ github.run_number }}" # the temporary Perforce client name to use while validating the git migration
+
+  DEPOT_NAME: "source/src-cli" # the name of the Perforce depot to validate the git migration against
 
 jobs:
   validate-migration:
@@ -13,35 +22,54 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      # install p4 client from Perforce
-      - name: "Install p4-fusion client"
+
+      - name: "Install Perforce CLI"
         uses: perforce/setup-p4@1.0.2
         with:
           command: "help"
           p4_version: 23.1
 
-      - name: "Install dependencies"
+      - name: "Install c++ compilation dependencies"
         run: |
           sudo apt-get update
-          sudo apt-get install gettext --yes # for envsubst 
-          sudo apt-get install git make cmake g++ --yes # p4-fusion dependencies
-          
-          # download p4-fusion headers
-          curl -L https://www.perforce.com/downloads/perforce/r22.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.0.2.tgz --output p4.tgz
+          sudo apt-get install git make cmake clang --yes # p4-fusion dependencies
+
+      - name: "Cache Perforce API headers"
+        id: cache-p4api
+        uses: actions/cache@v2
+        with:
+          path: vendor/helix-core-api/linux
+          key: ${{ runner.os }}-p4api-${{ env.P4_DOWNLOAD_URL }}
+
+      - name: "Download Perforce API headers"
+        if: ${{ steps.cache-p4api.outputs.cache-hit != 'true' }}
+        run: |
+          curl -L "${P4_DOWNLOAD_URL}" --output p4.tgz
           mkdir -p vendor/helix-core-api/linux
           tar -C vendor/helix-core-api/linux -xzf p4.tgz --strip 1
 
-          # compile openssl
+      - name: "Cache OpenSSL"
+        uses: actions/cache@v2
+        id: cache-openssl
+        with:
+          path: ${{ env.OPENSSL_INSTALL_DIR }}
+          key: ${{ runner.os }}-openssl-${{ env.OPENSSL_DOWNLOAD_URL }}
+
+      - name: "Compile OpenSSL"
+        if: ${{ steps.cache-openssl.outputs.cache-hit != 'true' }}
+        run: |
           mkdir openssl-src
-          curl -L https://www.openssl.org/source/openssl-1.0.2t.tar.gz --output openssl.tgz
+          curl -L "${OPENSSL_DOWNLOAD_URL}" --output openssl.tgz
           tar -C openssl-src -xzf openssl.tgz --strip 1
           pushd openssl-src
-          ./config --prefix=/tmp/openssl-install
+          ./config --prefix="${OPENSSL_INSTALL_DIR}" --static
           make install
           popd 
 
-
-      - name: "run validate migration script"
-        run: bash .github/workflows/run-test.sh
+      - name: "Run validate migration script"
+        run: |
+          sudo apt-get install gettext --yes # for envsubst 
+          .github/workflows/run-test.sh
         env:
-          OPENSSL_ROOT_DIR: "/tmp/openssl-install"
+          OPENSSL_ROOT_DIR: ${{ env.OPENSSL_INSTALL_DIR }}
+          CXX: "clang"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ core
 
 # Test output.
 /verify/
+
+# Ignore secert and env files
+**/**/*.secrets
+**/**/*.env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,6 @@ add_subdirectory(vendor)
 add_subdirectory(p4-fusion)
 
 if (BUILD_TESTS)
-    message(STATUS "Building tests ")
+    message(STATUS "Building tests")
     add_subdirectory(tests)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,13 @@ if (NOT DEFINED OPENSSL_ROOT_DIR)
     endif ()
 endif ()
 
-set(CMAKE_C_COMPILER "/usr/bin/gcc")
-set(CMAKE_CXX_COMPILER "/usr/bin/g++")
+if (NOT DEFINED CMAKE_C_COMPILER)
+    set(CMAKE_C_COMPILER "/usr/bin/gcc")
+endif ()
+
+if (NOT DEFINED CMAKE_CXX_COMPILER)
+    set(CMAKE_CXX_COMPILER "/usr/bin/g++")
+endif ()
 
 option(MTR_ENABLED "Enable minitrace profiling" OFF)
 option(BUILD_TESTS "Build tests" OFF)
@@ -33,6 +38,8 @@ set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_C_FLAGS_DEBUG "-g -O0")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+
+set(CMAKE_CXX_FLAGS "$ENV{CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 project(
         p4-fusion
@@ -54,6 +61,6 @@ add_subdirectory(vendor)
 add_subdirectory(p4-fusion)
 
 if (BUILD_TESTS)
-    message(STATUS "Building tests")
+    message(STATUS "Building tests ")
     add_subdirectory(tests)
 endif ()

--- a/generate_cache.sh
+++ b/generate_cache.sh
@@ -5,41 +5,41 @@ cd build
 rm CMakeCache.txt
 
 cmakeArgs=(
-    -DCMAKE_BUILD_TYPE=$1
-    -DBUILD_SHARED_LIBS=OFF
-    -DBUILD_CLAR=OFF
-    -DBUILD_EXAMPLES=OFF
-    -DUSE_BUNDLED_ZLIB=ON
-    -DREGEX_BACKEND=builtin
-    -DTHREADSAFE=ON
-    -DUSE_SSH=OFF
-    -DUSE_HTTPS=OFF
-    -DUSE_THREADS=ON
-    -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-"/usr/local/ssl"}"
-    -DCMAKE_C_COMPILER=/usr/bin/gcc
-    -DCMAKE_CXX_COMPILER=/usr/bin/g++
+  -DCMAKE_BUILD_TYPE=$1
+  -DBUILD_SHARED_LIBS=OFF
+  -DBUILD_CLAR=OFF
+  -DBUILD_EXAMPLES=OFF
+  -DUSE_BUNDLED_ZLIB=ON
+  -DREGEX_BACKEND=builtin
+  -DTHREADSAFE=ON
+  -DUSE_SSH=OFF
+  -DUSE_HTTPS=OFF
+  -DUSE_THREADS=ON
+  -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-"/usr/local/ssl"}"
+  -DCMAKE_C_COMPILER="${CMAKE_C_COMPILER:-"/usr/bin/gcc"}"
+  -DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER:-"/usr/bin/g++"}"
 )
 
 # Decide if tests/ should be built
 if [[ "$2" == *"t"* ]]; then
-    cmakeArgs+=(
-        -DBUILD_TESTS=ON
-    )
+  cmakeArgs+=(
+    -DBUILD_TESTS=ON
+  )
 else
-    cmakeArgs+=(
-        -DBUILD_TESTS=OFF
-    )
+  cmakeArgs+=(
+    -DBUILD_TESTS=OFF
+  )
 fi
 
 # Decide if profiling needs to be enabled
 if [[ "$2" == *"p"* ]]; then
-    cmakeArgs+=(
-        -DMTR_ENABLED=ON
-    )
+  cmakeArgs+=(
+    -DMTR_ENABLED=ON
+  )
 else
-    cmakeArgs+=(
-        -DMTR_ENABLED=OFF
-    )
+  cmakeArgs+=(
+    -DMTR_ENABLED=OFF
+  )
 fi
 
 echo "Using CMake arguments: \n${cmakeArgs[@]}"

--- a/generate_cache.sh
+++ b/generate_cache.sh
@@ -15,7 +15,7 @@ cmakeArgs=(
     -DUSE_SSH=OFF
     -DUSE_HTTPS=OFF
     -DUSE_THREADS=ON
-    -DOPENSSL_ROOT_DIR=/usr/local/ssl
+    -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-"/usr/local/ssl"}"
     -DCMAKE_C_COMPILER=/usr/bin/gcc
     -DCMAKE_CXX_COMPILER=/usr/bin/g++
 )


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/57645

This PR adds a new check, validate-migration, that:

- Downloads the perforce headers (if they aren't cached)
- Downloads and statically compiles OpenSSL (if it isn't cached)
- Downloads the C++ toolchains (gcc, clang, etc.)
- Prepares a Perforce client to use (while also trying to clean up after itself)
- Builds p4-fusion using one of the following [sanitizers](https://github.com/google/sanitizers) 
	- Address sanitizer
	- Leak sanitizer
	- Undefined behavior sanitizer 
	- (No sanitizer) 
- Runs the validate migration script against the src-cli depot on perforce.sgdev.org


## Notes

1. When trying to compiler p4-fusion with clang in CI (CMAKE_CXX_COMPILER="clang"), I kept running into issues where for whatever reason the C++ standard library headers weren't getting linked. I wasn't able to figure this out yet, so I've fallen back to just using gcc instead. **This means that the [`memory` sanitizer](https://github.com/google/sanitizers/wiki/MemorySanitizer) isn't running yet**, since only clang supports it. This will be addressed in a follow up PR. 

2. Apparently, the `thread` sanitizer has already found a race condition in our code: https://github.com/sourcegraph/p4-fusion/actions/runs/6750470865/job/18352919677?pr=10

## Test plan

This PR is the test.
