### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
+++ b/.github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
@@ -9,9 +9,10 @@ set -euxo pipefail
 
 export P4USER="${P4USER:-"admin"}"                       # the name of the Perforce superuser that the script will use to create the depot
 export P4PORT="${P4PORT:-"ssl:perforce.sgdev.org:1666"}" # the address of the Perforce server to connect to
-
-export DEPOT_NAME="${DEPOT_NAME:-"source/src-cli"}"      # the name of the depot that the script will create on the server
 export P4CLIENT="${P4CLIENT:-"integration-test-client"}" # the name of the temporary client that the script will use while it creates the depot
+
+export NUM_NETWORK_THREADS="${NUM_NETWORK_THREADS:-"64"}" # the number of network threads to use when running p4-fusion
+export DEPOT_NAME="${DEPOT_NAME:-"source/src-cli"}"      # the name of the depot that the script will create on the server
 
 TMP="$(mktemp -d)"
 export DEPOT_DIR="${TMP}/${DEPOT_NAME}"
@@ -75,7 +76,7 @@ echo "::group::{Run p4-fusion against the downloaded depot}"
     --client "${P4CLIENT}"
     --user "$P4USER"
     --src "${GIT_DEPOT_DIR}"
-    --networkThreads 64
+    --networkThreads "${NUM_NETWORK_THREADS}"
     --port "${P4PORT}"
     --lookAhead 15000
     --printBatch 1000

--- a/.github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
+++ b/.github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
@@ -7,7 +7,7 @@ export TEMPLATES="${SCRIPT_ROOT}/templates"
 
 set -euxo pipefail
 
-export P4USER="${P4USER:-"admin"}"                   # the name of the Perforce superuser that the script will use to create the depot
+export P4USER="${P4USER:-"admin"}"                       # the name of the Perforce superuser that the script will use to create the depot
 export P4PORT="${P4PORT:-"ssl:perforce.sgdev.org:1666"}" # the address of the Perforce server to connect to
 
 export DEPOT_NAME="${DEPOT_NAME:-"source/src-cli"}"      # the name of the depot that the script will create on the server
@@ -23,25 +23,12 @@ p4 trust -f -y
 
 cleanup() {
   # ensure that we don't leave a client behind (using up one of our licenses)
-  delete_perforce_client
+  "${SCRIPT_ROOT}/delete-perforce-client.sh"
 
   # delete temp folders
   rm -rf "${TMP}" || true
 }
 trap cleanup EXIT
-
-# delete_perforce_client deletes the client specified by "$P4CLIENT"
-# if it exists on the Perforce server.
-#
-## P4 CLI reference(s):
-##
-## https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_client.html
-delete_perforce_client() {
-  if p4 clients | awk '{print $2}' | grep -Fxq "${P4CLIENT}"; then
-    # delete the client
-    p4 client -f -Fs -d "${P4CLIENT}"
-  fi
-}
 
 echo "::group::{Ensure that Perforce credentials are valid}"
 {
@@ -55,7 +42,7 @@ Try using 'p4 -u ${P4USER} login -a' to generate a session ticket.
 See '${handbook_link}' for more information.
 END
 
-  exit 1
+    exit 1
   fi
 }
 
@@ -66,7 +53,8 @@ echo "::group::{Create temporary Perforce client}"
   printf "(re)creating temporary client '%s'..." "$P4CLIENT"
 
   # delete older copy of client (if it exists)
-  delete_perforce_client
+  "${SCRIPT_ROOT}/delete-perforce-client.sh"
+
   # create new client
   P4_CLIENT_HOST="$(hostname)" envsubst <"${TEMPLATES}/client.tmpl" | p4 client -i
 

--- a/.github/workflows/validate-migration-scripts/delete-perforce-client.sh
+++ b/.github/workflows/validate-migration-scripts/delete-perforce-client.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+SCRIPT_ROOT="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+cd "${SCRIPT_ROOT}/../../.."
+
+set -euxo pipefail
+
+export P4USER="${P4USER:-"admin"}"                       # the name of the Perforce superuser that the script will use to create the depot
+export P4PORT="${P4PORT:-"ssl:perforce.sgdev.org:1666"}" # the address of the Perforce server to connect to   # the name of the depot that the script will create on the server
+export P4CLIENT="${P4CLIENT:-"integration-test-client"}" # the name of the temporary client that the script will use while it creates the depot
+
+# delete_perforce_client deletes the client specified by "$P4CLIENT"
+# if it exists on the Perforce server.
+#
+## P4 CLI reference(s):
+##
+## https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_client.html
+
+if p4 clients | awk '{print $2}' | grep -Fxq "${P4CLIENT}"; then
+  # delete the client
+  p4 client -f -Fs -d "${P4CLIENT}"
+fi

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -97,10 +97,12 @@ jobs:
           ;;
         
           valgrindMemcheck)
+            OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/rand/md_rand.c#L490-L500
             VALGRIND_FLAGS="--tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes"
           ;;
         
           valgrindHelgrind)
+            OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/rand/md_rand.c#L490-L500
             VALGRIND_FLAGS="--tool=helgrind --track-lockorders=yes --history-level=full" 
           ;;
         

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -21,11 +21,6 @@ env:
   LLVM_PROJECT_SOURCE_DIR: "/tmp/llvm-project-src"
   LLVM_PROJECT_INSTALL_DIR: "/tmp/llvm-project-install"
 
-  VALGRIND_DOWNLOAD_URL: "https://sourceware.org/pub/valgrind/valgrind-3.22.0.tar.bz2"
-  VALGRIND_INSTALLATION_DIR: "/usr"
-  VALGRIND_SOURCE_DIR: "/tmp/valgrind-src"
-  VALGRIND_DOWNLOAD_DIR: "/tmp/valgrind-download"
-
   # Setup: Perforce credentials
   P4PORT: "ssl:perforce.sgdev.org:1666" # the address of the Perforce server to connect to
   P4USER: "admin" # the name of the Perforce user
@@ -33,12 +28,8 @@ env:
 
   # Setup: Enable sccache for faster builds
   SCCACHE_GHA_ENABLED: "true"
-  CC: "sccache clang-16"
-  CXX: "sccache clang++-16"
   CMAKE_C_COMPILER_LAUNCHER: "sccache"
   CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
-  CMAKE_CXX_COMPILER: "clang++-16"
-  CMAKE_C_COMPILER: "clang-16"
 
   # Setup: Sanitizer flags
   UBSAN_OPTIONS: "print_stacktrace=1" # print stack trace on undefined behavior
@@ -78,6 +69,7 @@ jobs:
           
           noTool)
             # No tool is being used, so we don't need to set any flags
+            CMAKE_CXX_FLAGS="-stdlib=libc++"
           ;;
               
           addressAndUndefinedSanitizer)
@@ -86,6 +78,12 @@ jobs:
             CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Address;Undefined"
+          
+            # Use Clang's Sanitizer implementation
+            CC="sccache clang-16"
+            CXX="sccache clang++-16"
+            CMAKE_CXX_COMPILER="clang++-16"
+            CMAKE_C_COMPILER="clang-16"
           ;;
         
           threadSanitizer)
@@ -94,16 +92,35 @@ jobs:
             CMAKE_CXX_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Thread"
+          
+            # Use Clang's Sanitizer implementation
+            CC="sccache clang-16"
+            CXX="sccache clang++-16"
+            CMAKE_CXX_COMPILER="clang++-16"
+            CMAKE_C_COMPILER="clang-16"
           ;;
         
           valgrindMemcheck)
             OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/rand/md_rand.c#L490-L500
             VALGRIND_FLAGS="--tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes"
+          
+            # Use GCC instead of Clang for Valgrind since Ubuntu ships with suppression files for glibc
+            CC="sccache gcc"
+            CXX="sccache g++"
+            CMAKE_CXX_COMPILER="g++"
+            CMAKE_C_COMPILER="gcc"
           ;;
         
           valgrindHelgrind)
             OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/rand/md_rand.c#L490-L500
             VALGRIND_FLAGS="--tool=helgrind --track-lockorders=yes --history-level=full" 
+          
+            # Use GCC instead of Clang for Valgrind since Ubuntu ships with suppression files for glibc
+
+            CC="sccache gcc"
+            CXX="sccache g++"
+            CMAKE_CXX_COMPILER="g++"
+            CMAKE_C_COMPILER="gcc"
           ;;
         
           *)
@@ -124,7 +141,7 @@ jobs:
             # that helps. 
             #
             # See https://valgrind.org/docs/manual/quick-start.html#quick-start.prepare for more information.
-            echo "CMAKE_CXX_FLAGS=-stdlib=libc++ -fno-omit-frame-pointer -g -O1 ${CMAKE_CXX_FLAGS:-""}"
+            echo "CMAKE_CXX_FLAGS=-fno-omit-frame-pointer -g -O1 ${CMAKE_CXX_FLAGS:-""}"
           
             echo "CMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS:-""}"
           
@@ -138,6 +155,12 @@ jobs:
           
             # Indicate whether we should build libc++ or not
             echo "BUILD_LIBCXX=${BUILD_LIBCXX:-"false"}"
+          
+            # Configure the C/C++ compilers
+            echo "CC=${CC:-"sccache clang-16"}"
+            echo "CXX=${CXX:-"sccache clang++-16"}"
+            echo "CMAKE_C_COMPILER=${CMAKE_C_COMPILER:-"clang-16"}"
+            echo "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER:-"clang++-16"}"
 
             # Set the temporary Perforce client name to use while validating the git migration
             echo "P4CLIENT=validate-migration-${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ matrix.tool }}"
@@ -177,6 +200,7 @@ jobs:
             g++
             libc6-dbg
             ninja-build
+            valgrind
           
             # Clang 16 dependencies
             clang-16
@@ -192,9 +216,6 @@ jobs:
         
           sudo apt-get update
           sudo apt-get install --yes "${PACKAGES[@]}"
-          
-          # remove any existing Valgrind installation since we're compiling it from source
-          sudo apt remove valgrind --yes
           
           EOF
 
@@ -224,63 +245,24 @@ jobs:
       - name: "Install LibCXX"
         if: ${{ env.BUILD_LIBCXX == 'true' }}
         run: |          
+          bash <<"EOF"
+          
+          set -euxo pipefail
+          
           pushd "${LLVM_PROJECT_SOURCE_DIR}"
           
           cmake -G Ninja -S runtimes -B build \
             -DCMAKE_INSTALL_PREFIX="${LLVM_PROJECT_INSTALL_DIR}" \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
-            -DCMAKE_C_COMPILER=clang-16 \
-            -DCMAKE_CXX_COMPILER=clang++-16 \
+            -DCMAKE_C_COMPILER="${CMAKE_C_COMPILER}" \
+            -DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER}" \
             -DLLVM_USE_SANITIZER="${LLVM_USE_SANITIZER:-""}" \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
           ninja --verbose -C build cxx cxxabi unwind
           ninja --verbose -C build install-cxx install-cxxabi install-unwind
-          
-          popd
-
-      - name: "Cache Valgrind bzip"
-        if: ${{ env.VALGRIND_FLAGS != '' }}
-        id: cache-valgrind-source
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.VALGRIND_DOWNLOAD_DIR }}
-          key: ${{ runner.os }}-valgrind-bzip-${{ env.VALGRIND_DOWNLOAD_URL }}
-
-      - name: "Download Valgrind bzip"
-        if: ${{ env.VALGRIND_FLAGS != '' && steps.cache-valgrind-source.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir -p "${VALGRIND_DOWNLOAD_DIR}" || true
-          pushd "${VALGRIND_DOWNLOAD_DIR}"
-          
-          curl -L "${VALGRIND_DOWNLOAD_URL}" --output valgrind.tar.bz2
-          popd
-
-      - name: "Compile Valgrind"
-        if: ${{ env.VALGRIND_FLAGS != '' }}
-        run: |
-          # Note, we need to compile valgrind from source to work around this issue: 
-          # https://bugs.kde.org/show_bug.cgi?id=452758
-          
-          bash <<"EOF"
-          
-          set -euxo pipefail
-          
-          # Unpack the Valgrind source
-          pushd "${VALGRIND_DOWNLOAD_DIR}"
-          
-          mkdir -p "${VALGRIND_SOURCE_DIR}" || true
-          tar -C "${VALGRIND_SOURCE_DIR}" -xjf valgrind.tar.bz2 --strip-components 1
-          
-          popd 
-          
-          pushd "${VALGRIND_SOURCE_DIR}"
-  
-          ./configure --prefix="${VALGRIND_INSTALLATION_DIR}"
-          make --jobs="$(nproc)"
-          sudo make install
           
           popd
           
@@ -355,7 +337,7 @@ jobs:
           ./config "${CONFIG_ARGS[@]}"
           make --jobs="$(nproc)"
           
-          sudo make install
+          sudo make install 
           
           popd
           

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -81,6 +81,7 @@ jobs:
           ;;
               
           addressAndUndefinedSanitizer)
+            BUILD_LIBCXX="true"
             OPENSSL_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE -DPEDANTIC"
             CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
@@ -88,6 +89,7 @@ jobs:
           ;;
         
           threadSanitizer)
+            BUILD_LIBCXX="true"
             OPENSSL_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
             CMAKE_CXX_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
@@ -131,6 +133,9 @@ jobs:
 
             # Set the flags for compiling OpenSSL
             echo "OPENSSL_FLAGS=${OPENSSL_FLAGS:-""}"
+          
+            # Indicate whether we should build libc++ or not
+            echo "BUILD_LIBCXX=${BUILD_LIBCXX:-"false"}"
 
             # Set the temporary Perforce client name to use while validating the git migration
             echo "P4CLIENT=validate-migration-${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ matrix.tool }}"
@@ -192,6 +197,7 @@ jobs:
           EOF
 
       - name: "Cache LLVM project gzip"
+        if : ${{ env.BUILD_LIBCXX == 'true' }}
         id: cache-llvm-project-source
         uses: actions/cache@v2
         with:
@@ -199,7 +205,7 @@ jobs:
           key: ${{ runner.os }}-llvm-project-gzip-${{ env.LLVM_PROJECT_DOWNLOAD_URL }}
 
       - name: "Download LLVM project"
-        if: ${{ steps.cache-llvm-project-source.outputs.cache-hit != 'true' }}
+        if: ${{ env.BUILD_LIBCXX == 'true' && steps.cache-llvm-project-source.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p "${LLVM_PROJECT_DOWNLOAD_DIR}" || true
           pushd "${LLVM_PROJECT_DOWNLOAD_DIR}"
@@ -208,11 +214,13 @@ jobs:
           popd
 
       - name: "Unpack LLVM project"
+        if: ${{ env.BUILD_LIBCXX == 'true' }}
         run: |
           mkdir -p "${LLVM_PROJECT_SOURCE_DIR}" || true
           tar -C "${LLVM_PROJECT_SOURCE_DIR}" -xzf "${LLVM_PROJECT_DOWNLOAD_DIR}/llvm-project.tar.gz" --strip-components 1
 
       - name: "Install LibCXX"
+        if: ${{ env.BUILD_LIBCXX == 'true' }}
         run: |          
           pushd "${LLVM_PROJECT_SOURCE_DIR}"
           

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -68,7 +68,6 @@ jobs:
           case ${{ matrix.tool }} in
           
           noTool)
-            # No tool is being used, so we don't need to set any flags
             CMAKE_CXX_FLAGS="-stdlib=libc++"
           ;;
               
@@ -78,12 +77,6 @@ jobs:
             CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Address;Undefined"
-          
-            # Use Clang's Sanitizer implementation
-            CC="sccache clang-16"
-            CXX="sccache clang++-16"
-            CMAKE_CXX_COMPILER="clang++-16"
-            CMAKE_C_COMPILER="clang-16"
           ;;
         
           threadSanitizer)
@@ -92,12 +85,6 @@ jobs:
             CMAKE_CXX_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Thread"
-          
-            # Use Clang's Sanitizer implementation
-            CC="sccache clang-16"
-            CXX="sccache clang++-16"
-            CMAKE_CXX_COMPILER="clang++-16"
-            CMAKE_C_COMPILER="clang-16"
           ;;
         
           valgrindMemcheck)
@@ -105,22 +92,15 @@ jobs:
             VALGRIND_FLAGS="--tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes"
           
             # Use GCC instead of Clang for Valgrind since Ubuntu ships with suppression files for glibc
-            CC="sccache gcc"
-            CXX="sccache g++"
-            CMAKE_CXX_COMPILER="g++"
-            CMAKE_C_COMPILER="gcc"
+            USE_GCC="true"
           ;;
         
           valgrindHelgrind)
             OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/rand/md_rand.c#L490-L500
-            VALGRIND_FLAGS="--tool=helgrind --track-lockorders=yes --history-level=full" 
-          
+            VALGRIND_FLAGS="--tool=helgrind --track-lockorders=yes --history-level=full"           
+            
             # Use GCC instead of Clang for Valgrind since Ubuntu ships with suppression files for glibc
-
-            CC="sccache gcc"
-            CXX="sccache g++"
-            CMAKE_CXX_COMPILER="g++"
-            CMAKE_C_COMPILER="gcc"
+            USE_GCC="true"
           ;;
         
           *)
@@ -157,11 +137,20 @@ jobs:
             echo "BUILD_LIBCXX=${BUILD_LIBCXX:-"false"}"
           
             # Configure the C/C++ compilers
-            echo "CC=${CC:-"sccache clang-16"}"
-            echo "CXX=${CXX:-"sccache clang++-16"}"
-            echo "CMAKE_C_COMPILER=${CMAKE_C_COMPILER:-"clang-16"}"
-            echo "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER:-"clang++-16"}"
 
+            if [[ "${USE_GCC:-"false"}" == "true" ]]; then
+              echo 'CC=sccache gcc'
+              echo 'CXX=sccache g++'
+              echo 'CMAKE_C_COMPILER=gcc'
+              echo 'CMAKE_CXX_COMPILER=g++'
+            else
+              # use clang 
+              echo 'CC=sccache clang-16'
+              echo 'CXX=sccache clang++-16'
+              echo 'CMAKE_C_COMPILER=clang-16'
+              echo 'CMAKE_CXX_COMPILER=clang++-16'
+            fi 
+        
             # Set the temporary Perforce client name to use while validating the git migration
             echo "P4CLIENT=validate-migration-${{ github.ref_name }}-${{ github.sha }}-${{ github.run_number }}-${{ matrix.tool }}"
           } >>"$GITHUB_ENV"

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -33,8 +33,8 @@ env:
 
   # Setup: Enable sccache for faster builds
   SCCACHE_GHA_ENABLED: "true"
-  CC: "clang-16"
-  CXX: "clang++-16"
+  CC: "sccache clang-16"
+  CXX: "sccache clang++-16"
   CMAKE_C_COMPILER_LAUNCHER: "sccache"
   CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
   CMAKE_CXX_COMPILER: "clang++-16"
@@ -147,7 +147,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: "Run sscache"
+      - name: "Run sccache"
         uses: mozilla-actions/sccache-action@v0.0.3
         with:
           version: "v0.6.0"

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -82,14 +82,14 @@ jobs:
               
           addressAndUndefinedSanitizer)
             OPENSSL_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE -DPEDANTIC"
-            CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
+            CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Address;Undefined"
           ;;
         
           threadSanitizer)
             OPENSSL_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
-            CMAKE_CXX_FLAGS="-fsanitize=thread -fno-sanitize-recover=all"
+            CMAKE_CXX_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Thread"
           ;;
@@ -356,7 +356,7 @@ jobs:
         env:
           OPENSSL_ROOT_DIR: ${{ env.OPENSSL_INSTALL_DIR }}
           USE_VALGRIND: ${{ env.VALGRIND_FLAGS != '' }}
-          LIBCXX_INSTALL_DIR: $${{ env.LLVM_PROJECT_INSTALL_DIR }}
+          LIBCXX_INSTALL_DIR: ${{ env.LLVM_PROJECT_INSTALL_DIR }}
 
       - name: "Ensure p4 client is deleted"
         if: always()

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -125,6 +125,10 @@ jobs:
           
             echo "CMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS:-""}"
           
+            # Set the number of parallel jobs to use when compiling
+            # See https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html for more information
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$(($(nproc) + 1))"
+          
             echo "LLVM_USE_SANITIZER=${LLVM_USE_SANITIZER:-""}"
 
             # Set the flags for compiling Valgrind
@@ -324,7 +328,7 @@ jobs:
           done
           
           ./config "${CONFIG_ARGS[@]}"
-          make --jobs="$(nproc)"
+          make --jobs="$(($(nproc) + 1))"
           
           sudo make install 
           
@@ -334,7 +338,15 @@ jobs:
 
       - name: "Build P4 Fusion and run validate migration script"
         run: |
+          bash <<"EOF"
+          
+          set -euxo pipefail
+          
+          export NUM_NETWORK_THREADS="$(($(nproc) + 1))" # use one more than the number of cores
+          
           timeout --verbose 30m .github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
+          
+          EOF
         env:
           OPENSSL_ROOT_DIR: ${{ env.OPENSSL_INSTALL_DIR }}
           USE_VALGRIND: ${{ env.VALGRIND_FLAGS != '' }}

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -81,14 +81,14 @@ jobs:
           ;;
               
           addressAndUndefinedSanitizer)
-            OPENSSL_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE"
-            CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
+            OPENSSL_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++ -fPIE -DPEDANTIC"
+            CMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Address;Undefined"
           ;;
         
           threadSanitizer)
-            OPENSSL_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -stdlib=libc++"
+            OPENSSL_FLAGS="-fsanitize=thread -fno-sanitize-recover=all -nostdinc++ -nostdlib++ -fPIE -stdlib=libc++"
             CMAKE_CXX_FLAGS="-fsanitize=thread -fno-sanitize-recover=all"
             CMAKE_EXE_LINKER_FLAGS="-lc++ -lc++abi -lunwind -pie"
             LLVM_USE_SANITIZER="Thread"

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -334,7 +334,7 @@ jobs:
 
       - name: "Build P4 Fusion and run validate migration script"
         run: |
-          timeout --verbose 1h .github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
+          timeout --verbose 30m .github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
         env:
           OPENSSL_ROOT_DIR: ${{ env.OPENSSL_INSTALL_DIR }}
           USE_VALGRIND: ${{ env.VALGRIND_FLAGS != '' }}

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -88,7 +88,7 @@ jobs:
           ;;
         
           valgrindMemcheck)
-            OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/rand/md_rand.c#L490-L500
+            OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/Configure#L113-L124
             VALGRIND_FLAGS="--tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes"
           
             # Use GCC instead of Clang for Valgrind since Ubuntu ships with suppression files for glibc
@@ -96,7 +96,7 @@ jobs:
           ;;
         
           valgrindHelgrind)
-            OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/crypto/rand/md_rand.c#L490-L500
+            OPENSSL_FLAGS="-DPURIFY" # See https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/Configure#L113-L124
             VALGRIND_FLAGS="--tool=helgrind --track-lockorders=yes --history-level=full"           
             
             # Use GCC instead of Clang for Valgrind since Ubuntu ships with suppression files for glibc

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -8,10 +8,10 @@ concurrency:
 
 env:
   # Setup: Constants for downloading and compiling dependencies
-  P4_DOWNLOAD_URL: "https://www.perforce.com/downloads/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.0.2.tgz"
+  P4_DOWNLOAD_URL: "https://cdist2.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz"
   P4_DOWNLOAD_DIR: "/tmp/p4-download"
 
-  OPENSSL_DOWNLOAD_URL: "https://www.openssl.org/source/openssl-1.0.2u.tar.gz"
+  OPENSSL_DOWNLOAD_URL: "https://www.openssl.org/source/openssl-1.1.1w.tar.gz"
   OPENSSL_SOURCE_DIR: "/tmp/openssl-src"
   OPENSSL_INSTALL_DIR: "/tmp/openssl-install"
   OPENSSL_DOWNLOAD_DIR: "/tmp/openssl-download"

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -340,6 +340,7 @@ jobs:
   
           CONFIG_ARGS=(
             --prefix="${OPENSSL_INSTALL_DIR}"
+            --openssldir="${OPENSSL_INSTALL_DIR}" 
           )
           
           read -r -a array <<<"${OPENSSL_FLAGS:-}"

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -20,7 +20,6 @@ env:
   LLVM_PROJECT_DOWNLOAD_DIR: "/tmp/llvm-project-download"
   LLVM_PROJECT_SOURCE_DIR: "/tmp/llvm-project-src"
   LLVM_PROJECT_INSTALL_DIR: "/tmp/llvm-project-install"
-  CLANG_INSTALL_DIR: "/tmp/clang-install"
 
   VALGRIND_DOWNLOAD_URL: "https://sourceware.org/pub/valgrind/valgrind-3.22.0.tar.bz2"
   VALGRIND_INSTALLATION_DIR: "/usr"
@@ -213,37 +212,6 @@ jobs:
         run: |
           mkdir -p "${LLVM_PROJECT_SOURCE_DIR}" || true
           tar -C "${LLVM_PROJECT_SOURCE_DIR}" -xzf "${LLVM_PROJECT_DOWNLOAD_DIR}/llvm-project.tar.gz" --strip-components 1
-
-#      - name: "Install Clang"
-#        run: |
-#          bash <<"EOF"
-#
-#            set -euxo pipefail
-#
-#            pushd "${LLVM_PROJECT_SOURCE_DIR}"
-#
-#            mkdir build
-#            pushd build
-#
-#            cmake -DLLVM_ENABLE_PROJECTS=clang \
-#                  -DCMAKE_INSTALL_PREFIX="${CLANG_INSTALL_DIR}" \
-#                  -DCMAKE_BUILD_TYPE=Release \
-#                  -DCMAKE_C_COMPILER=clang \
-#                  -DCMAKE_CXX_COMPILER=clang++ \
-#                  -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-#                  -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-#                  -G "Unix Makefiles" \
-#                  ../llvm
-#
-#            echo "$CLANG_INSTALL_DIR" >> "$GITHUB_PATH"
-#
-#            make --jobs="$(nproc)"
-#            sudo apt remove clang --yes
-#
-#            popd
-#            popd
-#
-#          EOF
 
       - name: "Install LibCXX"
         run: |          

--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -189,7 +189,6 @@ jobs:
           # remove any existing Valgrind installation since we're compiling it from source
           sudo apt remove valgrind --yes
           
-          
           EOF
 
       - name: "Cache LLVM project gzip"
@@ -353,7 +352,7 @@ jobs:
 
       - name: "Build P4 Fusion and run validate migration script"
         run: |
-          .github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
+          timeout --verbose 1h .github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
         env:
           OPENSSL_ROOT_DIR: ${{ env.OPENSSL_INSTALL_DIR }}
           USE_VALGRIND: ${{ env.VALGRIND_FLAGS != '' }}
@@ -362,4 +361,4 @@ jobs:
       - name: "Ensure p4 client is deleted"
         if: always()
         run: |
-          timeout 30 p4 client -f -Fs -d "${P4CLIENT}" || true
+          timeout --verbose 30s .github/workflows/validate-migration-scripts/delete-perforce-client.sh


### PR DESCRIPTION
This PR makes the following CI fixes: cc @varungandhi-src 

- It sets the -DPEDANTIC cmake flag when building OpenSSL with the undefined sanitizer, as noted by the [documentation](https://wiki.openssl.org/index.php/Compilation_and_Installation):

	>`-DPEDANTIC` 	Defines `PEDANTIC`. The library will avoid some undefined behavior, like casting an unaligned byte array to a different pointer type. This define should be used if building OpenSSL with undefined behavior sanitizer (`-fsanitize=undefined`).

- It upgrades the version of openssl that we were using in CI to OpenSSL 1.1.1 (and, consequently, the perforce api headers that we download). 
	- 	This seems to have gotten rid of
		- all the data races that thread sanitizer was reporting
		- many of the races that helgrind reports 
	- Perforce's own [dev notes](https://www.perforce.com/perforce/doc.current/user/p4devnotes.txt) recommend using at least 1.1.1, but I don't know why 1.0.2 is still supported.	
	- I found this interesting blog on OpenSSL's thread support in 1.0.2: https://www.openssl.org/blog/blog/2017/02/21/threads/. It indicates that applications had to register the appropriate callbacks to correct lock objects at _runtime_, which was easy to miss / misuse? (I wonder if the perforce library also runs into this...)

- Switches Valgrind runs to use gcc instead of clang.
	- 	I noticed in the [Ubuntu changelog for their Valgrind package](http://changelogs.ubuntu.com/changelogs/pool/main/v/valgrind/valgrind_3.15.0-1ubuntu9/changelog) that they bundle [suppressions](https://valgrind.org/docs/manual/manual-core.html#manual-core.suppress) for glibc in their package. I don't believe we get these if we a from source valgrind, so I switched our toolchain to build with gcc when running valgrind to see if it'd cut down on some of the noisiness. I might revisit this after we fix the remaining helgrind issues to see if we can switch everything back to clang (I'm not sure how much effect this really had). 

- It fixes the environment variable LIBCXX_INSTALL_DIR, which previously had an `$` prefixing the folder path (e.x.: `$/tmp/llvm-install-dir`

- It now only builds LIBCXX from source for thread, address, and undefined sanitizer which saves build time. 

- It now times out the validate migration script after an hour (and it should never take this long under normal cirumstances)

## Test plan

CI