### PR TITLE
Clean up codebase clang-tidy warnings

### DIFF
--- a/p4-fusion/branch_set.cc
+++ b/p4-fusion/branch_set.cc
@@ -7,6 +7,7 @@
 #include "branch_set.h"
 #include "minitrace.h"
 #include <map>
+#include <memory>
 #include <utility>
 
 ChangedFileGroups::ChangedFileGroups()
@@ -155,7 +156,7 @@ struct branchIntegrationMap
 	void addTarget(const std::string& targetBranch, const FileData& fileData);
 
 	// note: not const, because it cleans out the branchGroups.
-	std::unique_ptr<ChangedFileGroups> createChangedFileGroups() { return std::unique_ptr<ChangedFileGroups>(new ChangedFileGroups(branchGroups, fileCount)); };
+	std::unique_ptr<ChangedFileGroups> createChangedFileGroups() { return std::make_unique<ChangedFileGroups>(branchGroups, fileCount); };
 };
 
 void branchIntegrationMap::addTarget(const std::string& targetBranch, const FileData& fileData)

--- a/p4-fusion/branch_set.h
+++ b/p4-fusion/branch_set.h
@@ -56,7 +56,7 @@ public:
 
 	// splitBranchPath If the relativeDepotPath matches, returns {branch alias, branch file path}.
 	//   Otherwise, returns {"", ""}
-	std::array<std::string, 2> SplitBranchPath(const std::string& relativeDepotPath) const;
+	[[nodiscard]] std::array<std::string, 2> SplitBranchPath(const std::string& relativeDepotPath) const;
 };
 
 // A singular view on the branches and a base view (acts as a filter to trim down affected files).
@@ -71,19 +71,19 @@ private:
 	FileMap m_view;
 
 	// stripBasePath remove the base path from the depot path, or "" if not in the base path.
-	std::string stripBasePath(const std::string& depotPath) const;
+	[[nodiscard]] std::string stripBasePath(const std::string& depotPath) const;
 
 	// splitBranchPath extract the branch name and path under the branch (no leading '/' on the path)
 	//    relativeDepotPath - already stripped from running stripBasePath.
-	std::array<std::string, 2> splitBranchPath(const std::string& relativeDepotPath) const;
+	[[nodiscard]] std::array<std::string, 2> splitBranchPath(const std::string& relativeDepotPath) const;
 
 public:
 	BranchSet(std::vector<std::string>& clientViewMapping, const std::string& baseDepotPath, const std::vector<std::string>& branches, bool includeBinaries);
 
 	// HasMergeableBranch is there a branch model that requires integration history?
-	bool HasMergeableBranch() const { return !m_branches.empty(); };
+	[[nodiscard]] bool HasMergeableBranch() const { return !m_branches.empty(); };
 
-	size_t Count() const { return m_branches.size(); };
+	[[nodiscard]] size_t Count() const { return m_branches.size(); };
 
 	// ParseAffectedFiles create collections of merges and commits.
 	// Breaks up the files into those that are within the view, with each item in the
@@ -91,5 +91,5 @@ public:
 	// This also has the side-effect of populating the relative path value in the file data.
 	//   ... the FileData object is copied, but it's underlying shared data is shared.  So, this
 	//       breaks the const.
-	std::unique_ptr<ChangedFileGroups> ParseAffectedFiles(const std::vector<FileData>& cl) const;
+	[[nodiscard]] std::unique_ptr<ChangedFileGroups> ParseAffectedFiles(const std::vector<FileData>& cl) const;
 };

--- a/p4-fusion/commands/client_result.h
+++ b/p4-fusion/commands/client_result.h
@@ -25,7 +25,7 @@ private:
 	ClientSpecData m_Data;
 
 public:
-	const ClientSpecData& GetClientSpec() const { return m_Data; }
+	[[nodiscard]] const ClientSpecData& GetClientSpec() const { return m_Data; }
 
 	void OutputStat(StrDict* varList) override;
 };

--- a/p4-fusion/commands/describe_result.cc
+++ b/p4-fusion/commands/describe_result.cc
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 #include "describe_result.h"
-#include "git_api.h"
 
 DescribeResult& DescribeResult::operator=(const DescribeResult& other)
 {
@@ -14,7 +13,7 @@ DescribeResult& DescribeResult::operator=(const DescribeResult& other)
 		return *this;
 	}
 
-	m_FileData = std::move(other.m_FileData);
+	m_FileData = other.m_FileData;
 
 	return *this;
 }

--- a/p4-fusion/commands/describe_result.h
+++ b/p4-fusion/commands/describe_result.h
@@ -20,7 +20,7 @@ private:
 
 public:
 	DescribeResult& operator=(const DescribeResult& other);
-	const std::vector<FileData>& GetFileData() const { return m_FileData; }
+	[[nodiscard]] const std::vector<FileData>& GetFileData() const { return m_FileData; }
 
 	void OutputStat(StrDict* varList) override;
 	int OutputStatPartial(StrDict* varList) override;

--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -5,7 +5,8 @@
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 #include "file_data.h"
-#include "git_api.h"
+
+FileAction extrapolateFileAction(std::string& action);
 
 FileDataStore::FileDataStore(std::string& _depotFile, std::string& _revision, std::string& action, std::string& type)
     : depotFile(_depotFile)
@@ -13,6 +14,7 @@ FileDataStore::FileDataStore(std::string& _depotFile, std::string& _revision, st
     , isBinary(STDHelpers::Contains(type, "binary"))
     , isExecutable(STDHelpers::Contains(type, "+x"))
     , isContentsPendingDownload(false)
+    , actionCategory(extrapolateFileAction(action))
 {
 	SetAction(action);
 }
@@ -75,8 +77,6 @@ void FileData::SetRelativePath(std::string& relativePath)
 {
 	m_data->relativePath = relativePath;
 }
-
-FileAction extrapolateFileAction(std::string& action);
 
 void FileDataStore::SetAction(std::string fileAction)
 {

--- a/p4-fusion/commands/file_data.h
+++ b/p4-fusion/commands/file_data.h
@@ -84,16 +84,16 @@ public:
 
 	void SetBlobOID(std::string&& blobOID);
 	void SetPendingDownload();
-	bool IsDownloadNeeded() const
+	[[nodiscard]] bool IsDownloadNeeded() const
 	{
 		std::lock_guard<std::mutex> lock(m_data->blobOIDMu);
 		return m_data->blobOID == nullptr && !m_data->isContentsPendingDownload;
 	};
 
-	const std::string& GetDepotFile() const { return m_data->depotFile; };
-	const std::string& GetRevision() const { return m_data->revision; };
-	const std::string& GetRelativePath() const { return m_data->relativePath; };
-	const std::string& GetBlobOID() const
+	[[nodiscard]] const std::string& GetDepotFile() const { return m_data->depotFile; };
+	[[nodiscard]] const std::string& GetRevision() const { return m_data->revision; };
+	[[nodiscard]] const std::string& GetRelativePath() const { return m_data->relativePath; };
+	[[nodiscard]] const std::string& GetBlobOID() const
 	{
 		std::lock_guard<std::mutex> lock(m_data->blobOIDMu);
 		if (m_data->blobOID == nullptr)
@@ -102,12 +102,12 @@ public:
 		}
 		return *m_data->blobOID;
 	};
-	bool IsDeleted() const { return m_data->isDeleted; };
-	bool IsIntegrated() const { return m_data->isIntegrated; };
-	const std::string& GetFromDepotFile() const { return m_data->fromDepotFile; };
+	[[nodiscard]] bool IsDeleted() const { return m_data->isDeleted; };
+	[[nodiscard]] bool IsIntegrated() const { return m_data->isIntegrated; };
+	[[nodiscard]] const std::string& GetFromDepotFile() const { return m_data->fromDepotFile; };
 
-	bool IsBinary() const { return m_data->isBinary; };
-	bool IsExecutable() const { return m_data->isExecutable; };
+	[[nodiscard]] bool IsBinary() const { return m_data->isBinary; };
+	[[nodiscard]] bool IsExecutable() const { return m_data->isExecutable; };
 
 	void Clear() { m_data->Clear(); };
 };

--- a/p4-fusion/commands/file_map.cc
+++ b/p4-fusion/commands/file_map.cc
@@ -85,15 +85,6 @@ void FileMap::InsertTranslationMapping(const std::vector<std::string>& mapping)
 	}
 }
 
-const std::vector<std::string> PATH_PREFIX_DESCRIPTIONS = {
-	// Order is important.
-	"share ",
-	"isolate ",
-	"import+ ",
-	"import ",
-	"exclude "
-};
-
 void FileMap::copyMapApiInto(MapApi& map) const
 {
 	std::unique_lock<std::mutex> lock(*mu);

--- a/p4-fusion/commands/file_map.h
+++ b/p4-fusion/commands/file_map.h
@@ -26,9 +26,9 @@ public:
 	FileMap();
 	FileMap(const FileMap& src);
 
-	bool IsInLeft(const std::string& fileRevision) const;
+	[[nodiscard]] bool IsInLeft(const std::string& fileRevision) const;
 
-	MapCase GetCaseSensitivity() const { return m_sensitivity; };
+	[[nodiscard]] MapCase GetCaseSensitivity() const { return m_sensitivity; };
 
 	// "//a/... b/..." format
 	void InsertTranslationMapping(const std::vector<std::string>& mapping);

--- a/p4-fusion/commands/filelog_result.h
+++ b/p4-fusion/commands/filelog_result.h
@@ -23,7 +23,7 @@ private:
 
 public:
 	FileLogResult& operator=(const FileLogResult& other);
-	const std::vector<FileData>& GetFileData() const { return m_FileData; }
+	[[nodiscard]] const std::vector<FileData>& GetFileData() const { return m_FileData; }
 
 	void OutputStat(StrDict* varList) override;
 };

--- a/p4-fusion/commands/info_result.h
+++ b/p4-fusion/commands/info_result.h
@@ -16,7 +16,7 @@ class InfoResult : public Result
 public:
 	InfoResult();
 
-	int GetServerTimezoneMinutes() const { return m_TimezoneMinutes; };
+	[[nodiscard]] int GetServerTimezoneMinutes() const { return m_TimezoneMinutes; };
 
 	void OutputStat(StrDict* varList) override;
 };

--- a/p4-fusion/commands/result.h
+++ b/p4-fusion/commands/result.h
@@ -15,18 +15,18 @@ class Result : public ClientUser
 public:
 	void HandleError(Error* e) override;
 
-	const Error& GetError() const { return m_Error; }
+	[[nodiscard]] const Error& GetError() const { return m_Error; }
 	/*
 	 * HasError returns true when the result contains an error.
 	 */
-	bool HasError() const
+	[[nodiscard]] bool HasError() const
 	{
 		return GetError().IsError();
 	}
 	/*
 	 * PrintError formats the contained error, if any, as a std::string.
 	 */
-	std::string PrintError() const
+	[[nodiscard]] std::string PrintError() const
 	{
 		if (!HasError())
 		{

--- a/p4-fusion/commands/users_result.h
+++ b/p4-fusion/commands/users_result.h
@@ -24,7 +24,7 @@ private:
 	std::unordered_map<UserID, UserData> m_Users;
 
 public:
-	const std::unordered_map<UserID, UserData>& GetUserEmails() const { return m_Users; }
+	[[nodiscard]] const std::unordered_map<UserID, UserData>& GetUserEmails() const { return m_Users; }
 
 	void OutputStat(StrDict* varList) override;
 };

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -7,7 +7,6 @@
 #include "git_api.h"
 
 #include <sstream>
-#include <cstdlib>
 
 #include "git2.h"
 #include "minitrace.h"
@@ -182,7 +181,7 @@ bool GitAPI::IsHEADExists() const
 	return errorCode != GIT_ENOTFOUND;
 }
 
-const std::string GitAPI::DetectLatestCL() const
+std::string GitAPI::DetectLatestCL() const
 {
 	MTR_SCOPE("Git", __func__);
 
@@ -427,7 +426,7 @@ BlobWriter GitAPI::WriteBlob() const
 		throw std::runtime_error("created blob writer before opening repository");
 	}
 
-	return { m_Repo };
+	return BlobWriter(m_Repo);
 }
 
 void BlobWriter::Write(const char* contents, int length)

--- a/p4-fusion/git_api.h
+++ b/p4-fusion/git_api.h
@@ -32,7 +32,7 @@ private:
 
 public:
 	BlobWriter() = delete;
-	BlobWriter(git_repository* repo);
+	explicit BlobWriter(git_repository* repo);
 
 	// Write creates a new ODB entry on the first call and continuous calls keep
 	// writing more data to it.
@@ -50,7 +50,7 @@ class Libgit2RAII
 {
 public:
 	Libgit2RAII() = delete;
-	Libgit2RAII(int fsyncEnable);
+	explicit Libgit2RAII(int fsyncEnable);
 	~Libgit2RAII();
 };
 
@@ -70,14 +70,14 @@ public:
 
 	// WriteBlob returns a new BlobWriter instance that allows to write a single
 	// blob to the repository's ODB.
-	BlobWriter WriteBlob() const;
+	[[nodiscard]] BlobWriter WriteBlob() const;
 
 	void InitializeRepository(bool noCreateBaseCommit);
 	void OpenRepository();
-	bool IsHEADExists() const;
-	bool IsRepositoryClonedFrom(const std::string& depotPath) const;
+	[[nodiscard]] bool IsHEADExists() const;
+	[[nodiscard]] bool IsRepositoryClonedFrom(const std::string& depotPath) const;
 	/* Checks if a previous commit was made and extracts the corresponding changelist number. */
-	const std::string DetectLatestCL() const;
+	[[nodiscard]] std::string DetectLatestCL() const;
 
 	/* files are cleared as they are visited. Empty targetBranch means HEAD. Only use this method on the main thread! */
 	std::string WriteChangelistBranch(

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -136,7 +136,7 @@ int Main(int argc, char** argv)
 			return 1;
 		}
 
-		resumeFromCL = std::move(git.DetectLatestCL());
+		resumeFromCL = git.DetectLatestCL();
 		SUCCESS("Detected last CL committed as CL " << resumeFromCL)
 	}
 
@@ -182,7 +182,7 @@ int Main(int argc, char** argv)
 	int networkThreads = arguments.GetNetworkThreads();
 	if (networkThreads > changes.size())
 	{
-		networkThreads = changes.size();
+		networkThreads = int(changes.size());
 	}
 	PRINT("Creating " << networkThreads << " network threads")
 	ThreadPool pool(networkThreads, srcPath, timezoneMinutes);

--- a/p4-fusion/p4_api.cc
+++ b/p4-fusion/p4_api.cc
@@ -136,7 +136,7 @@ bool P4API::CheckErrors(Error& e)
 	{
 		StrBuf msg;
 		e.Fmt(&msg);
-		ERR(msg.Text());
+		ERR(msg.Text())
 		return false;
 	}
 	return true;

--- a/p4-fusion/p4_api.h
+++ b/p4-fusion/p4_api.h
@@ -48,7 +48,7 @@ private:
 	bool Initialize();
 	bool Deinitialize();
 	bool Reinitialize();
-	bool CheckErrors(Error& e);
+	static bool CheckErrors(Error& e);
 
 	template <class T>
 	T Run(const char* command, const std::vector<std::string>& stringArguments, const std::function<T()>& creatorFunc);
@@ -67,7 +67,7 @@ public:
 	P4API();
 	~P4API();
 
-	bool IsDepotPathValid(const std::string& depotPath);
+	static bool IsDepotPathValid(const std::string& depotPath);
 	bool IsDepotPathUnderClientSpec(const std::string& depotPath);
 
 	TestResult TestConnection(int retries);

--- a/p4-fusion/thread.h
+++ b/p4-fusion/thread.h
@@ -16,7 +16,7 @@ class ThreadRAII
 {
 public:
 	ThreadRAII() = default;
-	ThreadRAII(std::thread&& t)
+	explicit ThreadRAII(std::thread&& t)
 	    : t(std::move(t))
 	{
 	}

--- a/p4-fusion/utils/arguments.cc
+++ b/p4-fusion/utils/arguments.cc
@@ -36,20 +36,19 @@ Arguments::Arguments(int argc, char** argv)
 
 		if (m_Parameters.find(name) != m_Parameters.end())
 		{
-			m_Parameters.at(name).valueList.push_back(argv[i + 1]);
+			m_Parameters.at(name).valueList.emplace_back(argv[i + 1]);
 			m_Parameters.at(name).isSet = true;
 		}
 		else
 		{
 			// TODO: Throw?
-			WARN("Unknown argument: " << name);
+			WARN("Unknown argument: " << name)
 		}
 	}
 }
 
-void Arguments::Print()
+void Arguments::Print() const
 {
-	auto noMerge = GetNoMerge();
 	auto depotPath = GetDepotPath();
 	auto srcPath = GetSourcePath();
 	auto fsyncEnable = GetFsyncEnable();

--- a/p4-fusion/utils/arguments.h
+++ b/p4-fusion/utils/arguments.h
@@ -24,40 +24,38 @@ class Arguments
 
 	std::map<std::string, ParameterData> m_Parameters;
 
-	std::string GetParameter(const std::string& argName) const;
-	int GetParameterInt(const std::string& argName) const;
-	bool GetParameterBool(const std::string& argName) const;
-	std::vector<std::string> GetParameterList(const std::string& argName) const;
+	[[nodiscard]] std::string GetParameter(const std::string& argName) const;
+	[[nodiscard]] int GetParameterInt(const std::string& argName) const;
+	[[nodiscard]] bool GetParameterBool(const std::string& argName) const;
+	[[nodiscard]] std::vector<std::string> GetParameterList(const std::string& argName) const;
 
 public:
 	Arguments(int argc, char** argv);
 	Arguments() = delete;
 
-	void Print();
+	void Print() const;
 	void RequiredParameter(const std::string& name, const std::string& helpText);
 	void OptionalParameter(const std::string& name, const std::string& defaultValue, const std::string& helpText);
 	void OptionalParameterList(const std::string& name, const std::string& helpText);
-	bool IsValid() const;
-	std::string Help() const;
+	[[nodiscard]] bool IsValid() const;
+	[[nodiscard]] std::string Help() const;
 
-	const ParameterData& GetParameterData(const std::string& name) const { return m_Parameters.at(name); }
-
-	std::string GetPort() const { return GetParameter("--port"); };
-	std::string GetUsername() const { return GetParameter("--user"); };
-	std::string GetDepotPath() const { return GetParameter("--path"); };
-	std::string GetSourcePath() const { return GetParameter("--src"); };
-	std::string GetClient() const { return GetParameter("--client"); };
-	int GetNetworkThreads() const { return GetParameterInt("--networkThreads"); };
-	int GetPrintBatch() const { return GetParameterInt("--printBatch"); };
-	int GetLookAhead() const { return GetParameterInt("--lookAhead"); };
-	int GetRetries() const { return GetParameterInt("--retries"); };
-	int GetRefresh() const { return GetParameterInt("--refresh"); };
-	bool GetFsyncEnable() const { return GetParameterBool("--fsyncEnable"); };
-	bool GetIncludeBinaries() const { return GetParameterBool("--includeBinaries"); };
-	int GetMaxChanges() const { return GetParameterInt("--maxChanges"); };
-	int GetFlushRate() const { return GetParameterInt("--flushRate"); };
-	bool GetNoColor() const { return GetParameterBool("--noColor"); };
-	bool GetNoMerge() const { return GetParameterBool("--noMerge"); };
-	bool GetNoBaseCommit() const { return GetParameterBool("--noBaseCommit"); };
-	std::vector<std::string> GetBranches() const { return GetParameterList("--branch"); };
+	[[nodiscard]] std::string GetPort() const { return GetParameter("--port"); };
+	[[nodiscard]] std::string GetUsername() const { return GetParameter("--user"); };
+	[[nodiscard]] std::string GetDepotPath() const { return GetParameter("--path"); };
+	[[nodiscard]] std::string GetSourcePath() const { return GetParameter("--src"); };
+	[[nodiscard]] std::string GetClient() const { return GetParameter("--client"); };
+	[[nodiscard]] int GetNetworkThreads() const { return GetParameterInt("--networkThreads"); };
+	[[nodiscard]] int GetPrintBatch() const { return GetParameterInt("--printBatch"); };
+	[[nodiscard]] int GetLookAhead() const { return GetParameterInt("--lookAhead"); };
+	[[nodiscard]] int GetRetries() const { return GetParameterInt("--retries"); };
+	[[nodiscard]] int GetRefresh() const { return GetParameterInt("--refresh"); };
+	[[nodiscard]] bool GetFsyncEnable() const { return GetParameterBool("--fsyncEnable"); };
+	[[nodiscard]] bool GetIncludeBinaries() const { return GetParameterBool("--includeBinaries"); };
+	[[nodiscard]] int GetMaxChanges() const { return GetParameterInt("--maxChanges"); };
+	[[nodiscard]] int GetFlushRate() const { return GetParameterInt("--flushRate"); };
+	[[nodiscard]] bool GetNoColor() const { return GetParameterBool("--noColor"); };
+	[[nodiscard]] bool GetNoMerge() const { return GetParameterBool("--noMerge"); };
+	[[nodiscard]] bool GetNoBaseCommit() const { return GetParameterBool("--noBaseCommit"); };
+	[[nodiscard]] std::vector<std::string> GetBranches() const { return GetParameterList("--branch"); };
 };

--- a/p4-fusion/utils/std_helpers.cc
+++ b/p4-fusion/utils/std_helpers.cc
@@ -31,16 +31,6 @@ bool STDHelpers::Contains(const std::string& str, const std::string& subStr)
 	return str.find(subStr) != std::string::npos;
 }
 
-void STDHelpers::Erase(std::string& source, const std::string& subStr)
-{
-	if (!Contains(source, subStr))
-	{
-		return;
-	}
-
-	source.erase(source.find(subStr), subStr.size());
-}
-
 void STDHelpers::StripSurrounding(std::string& source, const char c)
 {
 	const size_t size = source.size();
@@ -62,14 +52,4 @@ void STDHelpers::StripSurrounding(std::string& source, const char c)
 	{
 		source.erase(0, start);
 	}
-}
-
-std::array<std::string, 2> STDHelpers::SplitAt(const std::string& source, const char c, const size_t startAt)
-{
-	size_t pos = source.find(c, startAt);
-	if (pos != std::string::npos && pos < source.size())
-	{
-		return { source.substr(startAt, pos - startAt), source.substr(pos + 1) };
-	}
-	return { source, "" };
 }

--- a/p4-fusion/utils/std_helpers.h
+++ b/p4-fusion/utils/std_helpers.h
@@ -15,10 +15,5 @@ public:
 	static bool EndsWith(const std::string& str, const std::string& checkStr);
 	static bool StartsWith(const std::string& str, const std::string& checkStr);
 	static bool Contains(const std::string& str, const std::string& subStr);
-	static void Erase(std::string& source, const std::string& subStr);
-	static void StripSurrounding(std::string& source, const char c);
-
-	// Split the source into two strings at the first character 'c' after position 'startAt'.  The 'c' character is
-	// not included in the returned strings.  Text before the 'startAt' will not be included.
-	static std::array<std::string, 2> SplitAt(const std::string& source, const char c, const size_t startAt = 0);
+	static void StripSurrounding(std::string& source, char c);
 };

--- a/p4-fusion/utils/timer.cc
+++ b/p4-fusion/utils/timer.cc
@@ -6,8 +6,6 @@
  */
 #include "timer.h"
 
-const std::chrono::high_resolution_clock Timer::s_Clock;
-
 Timer::Timer()
     : m_StartTime(Now())
 {

--- a/p4-fusion/utils/timer.h
+++ b/p4-fusion/utils/timer.h
@@ -12,15 +12,13 @@ typedef std::chrono::time_point<std::chrono::high_resolution_clock> TimePoint;
 
 class Timer
 {
-	static const std::chrono::high_resolution_clock s_Clock;
-
 	TimePoint m_StartTime;
 
 public:
-	static TimePoint Now() { return s_Clock.now(); }
+	static TimePoint Now() { return std::chrono::high_resolution_clock::now(); }
 
 	Timer();
 
 	/// Get time spent since construction of this object in seconds
-	float GetTimeS() const { return (float)(s_Clock.now() - m_StartTime).count() * 1e-9; }
+	[[nodiscard]] float GetTimeS() const { return (float)(std::chrono::high_resolution_clock::now() - m_StartTime).count() * 1e-9; }
 };


### PR DESCRIPTION
So we don't always have so many unrelated changes in PRs.


## Test plan

CI. 