### PR TITLE
Cleanup log output

### DIFF
--- a/.github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
+++ b/.github/workflows/validate-migration-scripts/build-p4-fusion-and-run-validate-migration.sh
@@ -63,6 +63,9 @@ echo "::group::{Create temporary Perforce client}"
 }
 echo "::endgroup::"
 
+# Enable test output that helps this script understand what was written.
+export PRINT_TEST_OUTPUT=true
+
 echo "::group::{Build P4 Fusion}"
 {
   time (./generate_cache.sh Debug && ./build.sh)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(THREADSAFE "Threadsafe" ON)
 option(USE_SSH "Use SSH" OFF)
 option(USE_HTTPS "Use HTTPS" OFF)
 option(USE_THREADS "Use threads" ON)
+option(PRINT_TEST_OUTPUT "Print additional lines used for the validate-migration script" OFF)
 
 if (NOT DEFINED OPENSSL_ROOT_DIR)
     if (APPLE)
@@ -47,6 +48,12 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 set(CMAKE_CXX_FLAGS "$ENV{CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "$ENV{CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}")
+
+set(PRINT_TEST_OUTPUT $ENV{PRINT_TEST_OUTPUT})
+
+if (PRINT_TEST_OUTPUT)
+    add_definitions(-DPRINT_TEST_OUTPUT)
+endif ()
 
 project(
         p4-fusion

--- a/p4-fusion/branch_set.h
+++ b/p4-fusion/branch_set.h
@@ -36,7 +36,7 @@ private:
 public:
 	std::vector<BranchedFileGroup> branchedFileGroups;
 	int totalFileCount;
-	
+
 	ChangedFileGroups(std::vector<BranchedFileGroup>& groups, int totalFileCount);
 
 	static std::unique_ptr<ChangedFileGroups> Empty() { return std::unique_ptr<ChangedFileGroups>(new ChangedFileGroups); };

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -227,7 +227,6 @@ int Main(int argc, char** argv)
 	while (!changes.empty())
 	{
 		// Ensure the files are downloaded before committing them to the repository
-		PRINT("Waiting for download of CL " << changes.front().number << " to complete")
 		// First, wait until downloaded so the changelist is no longer referenced
 		// in worker threads.
 		changes.front().WaitForDownload();
@@ -265,8 +264,10 @@ int Main(int argc, char** argv)
 			    email,
 			    mergeFrom);
 
+#ifdef PRINT_TEST_OUTPUT
 			// For scripting/testing purposes...
 			PRINT("COMMIT:" << commitSHA << ":" << cl.number << ":" << branchGroup.targetBranch << ":")
+#endif
 			if (branchSet.Count() > 0)
 			{
 				SUCCESS(

--- a/runtest.sh
+++ b/runtest.sh
@@ -46,6 +46,9 @@ mkdir -p "${ROOT}/verify/p4home"
 mkdir -p "${ROOT}/verify/datadir"
 mkdir -p "${ROOT}/verify/p4datadir"
 
+# Enable test output that helps this script understand what was written.
+export PRINT_TEST_OUTPUT=true
+
 ./generate_cache.sh Debug
 
 ./build.sh


### PR DESCRIPTION
The 1.12 version of p4-fusion was less verbose which had the nice property that since we always show the last log line in the clone progress UI it would contains stats on the progress. This reverts to that, and makes the output required for our test script opt-in using a compile time flag.


## Test plan

CI and verified log output looks okay locally. 