### PR TITLE
Make sure threads are always joined when errors occur

### DIFF
--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -185,7 +185,7 @@ int Main(int argc, char** argv)
 		networkThreads = int(changes.size());
 	}
 	PRINT("Creating " << networkThreads << " network threads")
-	ThreadPool pool(networkThreads, srcPath, timezoneMinutes);
+	ThreadPool pool(networkThreads, srcPath, timezoneMinutes, p4);
 	SUCCESS("Created " << pool.GetThreadCount() << " threads in thread pool")
 
 	// Block signals from being handled by the main thread, and all future threads.

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -93,7 +93,7 @@ void ThreadPool::ShutDown()
 	}
 }
 
-ThreadPool::ThreadPool(const int size, const std::string& repoPath, const int tz)
+ThreadPool::ThreadPool(const int size, const std::string& repoPath, const int tz, P4API& p4)
     : m_HasShutDownBeenCalled(false)
     , exceptionHandlingThread(std::thread([this]()
           {
@@ -116,9 +116,7 @@ ThreadPool::ThreadPool(const int size, const std::string& repoPath, const int tz
 
 	for (int i = 0; i < size; i++)
 	{
-		// Initialize P4API here so we synchronously create them.
-		std::shared_ptr<P4API> p4 = std::make_shared<P4API>();
-		m_Threads.emplace_back([this, i, repoPath, p4, tz]()
+		m_Threads.emplace_back([this, i, repoPath, &p4, tz]()
 		    {
 				// Add some human-readable info to the tracing.
 				MTR_META_THREAD_NAME(("Worker #" + std::to_string(i)).c_str());
@@ -153,7 +151,7 @@ ThreadPool::ThreadPool(const int size, const std::string& repoPath, const int tz
 
 					try
 					{
-						job(*p4, git);
+						job(p4, git);
 					}
 					catch (const std::exception& e)
 					{

--- a/p4-fusion/thread_pool.h
+++ b/p4-fusion/thread_pool.h
@@ -41,7 +41,7 @@ private:
 	ThreadRAII exceptionHandlingThread;
 
 public:
-	ThreadPool(int size, const std::string& repoPath, int tz);
+	ThreadPool(int size, const std::string& repoPath, int tz, P4API& p4);
 	ThreadPool() = delete;
 	~ThreadPool();
 


### PR DESCRIPTION
## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
