### PR TITLE
Add GHA to build + upload to GCS with Nix

### DIFF
--- a/.github/workflows/nix-build-and-upload.yaml
+++ b/.github/workflows/nix-build-and-upload.yaml
@@ -4,8 +4,7 @@ on:
   push:
     branches: 
       - main
-      - nsc/nix-build # temporary
-  # pull_request:
+  pull_request:
 
 jobs:
   x86_64-darwin:
@@ -37,7 +36,7 @@ jobs:
       - uses: google-github-actions/upload-cloud-storage@v1
         # github.head_ref is only available for pull requests
         # if the event type is not pull_requet we have to use github.ref_name
-        # if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         with:
           path: './dist/'
           destination: 'p4-fusion/x86_64-darwin/'

--- a/.github/workflows/nix-build-and-upload.yaml
+++ b/.github/workflows/nix-build-and-upload.yaml
@@ -1,0 +1,108 @@
+name: nix_p4-fusion
+
+on:
+  push:
+    branches: 
+      - main
+      - nsc/nix-build # temporary
+  # pull_request:
+
+jobs:
+  x86_64-darwin:
+    name: Build p4-fusion x86_64-darwin
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v8
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: '🔓 Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.CTAGS_GCP_SERVICE_ACCOUNT }}
+      - name: Run `nix build`
+        run: |
+          nix build .#p4-fusion_openssl1_1-static
+      - name: Sign the binary 
+        # signing in ./result/bin will cause a cache miss on next invocation
+        run: |
+          mkdir -p dist
+          cp -L ./result/bin/p4-fusion* ./dist/
+          sudo codesign --force -s - ./dist/p4-fusion*
+      - name: Rename and prepare for upload
+        run: |
+          cd ./dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+      - name: Show hash of p4-fusion
+        run: |
+          shasum -a 256 ./dist/p4-fusion*
+      - uses: google-github-actions/upload-cloud-storage@v1
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        # if: ${{ github.ref_name == 'main' }}
+        with:
+          path: './dist/'
+          destination: 'p4-fusion/x86_64-darwin/'
+          glob: 'p4-fusion*'
+  aarch64-darwin:
+    name: Build p4-fusion aarch64-darwin
+    runs-on: macos-latest-xlarge
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: '🔓 Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.CTAGS_GCP_SERVICE_ACCOUNT }}
+      - name: Run `nix build`
+        run: |
+          nix build .#p4-fusion_openssl1_1-static
+      - name: Sign the binary 
+        # signing in ./result/bin will cause a cache miss on next invocation
+        run: |
+          mkdir -p dist
+          cp -L ./result/bin/p4-fusion* ./dist/
+          sudo codesign --force -s - ./dist/p4-fusion*
+      - name: Rename and prepare for upload
+        run: |
+          cd ./dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+      - name: Show hash of p4-fusion
+        run: |
+          shasum -a 256 ./dist/p4-fusion*
+      - uses: google-github-actions/upload-cloud-storage@v1
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.ref_name == 'main' }}
+        with:
+          path: './dist/'
+          destination: 'p4-fusion/aarch64-darwin/'
+          glob: 'p4-fusion*'
+  x86_64-linux:
+    name: Build p4-fusion x86_64-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: '🔓 Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.CTAGS_GCP_SERVICE_ACCOUNT }}
+      - name: Run `nix build`
+        run: |
+          nix build .#p4-fusion_openssl1_1-static
+      - name: Rename and prepare for upload
+        run: |
+          mkdir -p dist
+          cp -R -L ./result/bin/p4-fusion* dist/
+          cd dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+      - name: Show hash of p4-fusion
+        run: |
+          shasum -a 256 ./dist/p4-fusion*
+      - uses: google-github-actions/upload-cloud-storage@v1
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.ref_name == 'main' }}
+        with:
+          path: './dist/'
+          destination: 'p4-fusion/x86_64-linux/'
+          glob: 'p4-fusion*'

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ core
 # Ignore secert and env files
 **/**/*.secrets
 **/**/*.env
+
+# nix-related
+result
+source/
+outputs/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701693815,
+        "narHash": "sha256-7BkrXykVWfkn6+c1EhFA3ko4MLi3gVG0p9G96PNnKTM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "09ec6a0881e1a36c29d67497693a67a16f4da573",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "Flake for building p4-fusion with openssl1.1 and openssl3, dynamically and statically";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      forAllSystems = fn:
+        nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ]
+          (system: fn (import nixpkgs {
+            config.permittedInsecurePackages = [ "openssl-1.1.1w" ];
+            inherit system;
+          }));
+    in
+    {
+      packages = forAllSystems (pkgs:
+        let
+          helix-core-api-set = pkgs.callPackage ./nix/helix-core-api.nix { };
+          # pkgsStatic on x86_64-darwin is not yet functional,
+          # tracked in https://github.com/NixOS/nixpkgs/pull/256590 as static building
+          # is cross-compilation under the hood.
+          pkgsStatic = if pkgs.system == "x86_64-darwin" then pkgs else pkgs.pkgsStatic;
+          # until the above is resolved, we need these static workarounds for x86_64-darwin,
+          # but apply them to every system type as it doesn't harm them anyway.
+          # note also a http-parser workaround detailed in the below file.
+          static-deps-set = pkgsStatic.callPackage ./nix/static-deps.nix { };
+        in
+        {
+          p4-fusion_openssl3 = pkgs.callPackage ./nix/binary.nix {
+            helix-core-api-set = helix-core-api-set."3.0";
+          };
+
+          p4-fusion_openssl1_1 = pkgs.callPackage ./nix/binary.nix {
+            openssl = pkgs.openssl_1_1;
+            helix-core-api-set = helix-core-api-set."1.1";
+          };
+
+          p4-fusion_openssl3-static = pkgsStatic.callPackage ./nix/binary.nix {
+            inherit (static-deps-set) http-parser libiconv openssl pcre zlib;
+            helix-core-api-set = helix-core-api-set."3.0";
+          };
+
+          p4-fusion_openssl1_1-static = pkgsStatic.callPackage ./nix/binary.nix {
+            openssl = static-deps-set.openssl_1_1;
+            inherit (static-deps-set) http-parser libiconv pcre zlib;
+            helix-core-api-set = helix-core-api-set."1.1";
+          };
+        });
+
+      apps = forAllSystems (pkgs:
+        let
+          helix-core-api-set = pkgs.callPackage ./nix/helix-core-api.nix { };
+          checksum-printer = pkgs.writeShellScript "checksum-printer" (pkgs.callPackage ./nix/checksum-printer-script.nix { });
+          checksum-checker = pkgs.writeShellApplication {
+            name = "checksum-checker";
+            runtimeInputs = (builtins.attrValues helix-core-api-set."1.1") ++ (builtins.attrValues helix-core-api-set."3.0");
+            text = "echo 'All checksums are good!'";
+          };
+        in
+        {
+          print-checksums = {
+            program = "${checksum-printer}";
+            type = "app";
+          };
+          check-checksums = {
+            program = "${checksum-checker}/bin/checksum-checker";
+            type = "app";
+          };
+        });
+
+      devShells = forAllSystems (pkgs: { default = pkgs.callPackage ./nix/shell.nix { }; });
+
+      formatter = forAllSystems (pkgs: pkgs.nixpkgs-fmt);
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,35 @@
+# Nix for p4-fusion
+
+This Nix-based infrastructure aims to provide us with reproducible, deterministic and hermetic binary builds for provisioning with Bazel over in [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).
+
+Github Actions workflows are used to build and upload the binaries.
+
+**Note**: please reach out in [#discuss-dev-infra](https://sourcegraph.slack.com/archives/C04MYFW01NV) if you're experiencing issues or uncertainty with or just wanna chat about any of this, either locally or in Github Actions.
+
+We highly recommend the [Determinate Systems' Nix installer](https://github.com/DeterminateSystems/nix-installer) if you want/need to use or modify any of this locally.
+
+## Binary targets
+
+Build targets are provided for various combinations of target OS, architecture, OpenSSL version and static vs dynamic binaries. To build e.g. a static x86_64 Linux with OpenSSL 1.1, you would run `nix build .#p4-fusion_openssl1_1-static` on a Linux machine. Check the `packages` section of `nix flake show` for the full list of targets.
+
+## Troubleshooting
+
+### nix build fails with "hash mismatch" error referencing helix-core-api.drv
+
+In `./nix/helix-core-api.nix`, we specify the URLs for the helix-core-api dependency for different OpenSSL and system/arch combinations, along with a checksum for those archives (as required by Nix). Sometimes those URLs are re-used for updated archives of helix-core-api, which will cause a checksum mismatch similar to the following:
+
+```go
+building '/nix/store/cb2ssx8vykl1ghb4k87yp3q6wnvfvjj2-helix-core-api.drv'...
+error: hash mismatch in fixed-output derivation '/nix/store/cb2ssx8vykl1ghb4k87yp3q6wnvfvjj2-helix-core-api.drv':
+         specified: sha256-8yX9sjE1f798ns0UmHXz5I8kdpUXHS01FG46SU8nsZw=
+            got:    sha256-gaYvQOX8nvMIMHENHB0+uklyLcmeXT5gjGGcVC9TTtE=
+error: 1 dependencies of derivation '/nix/store/m409z1rq40bwzvvndbnghrrxm000zd9v-p4-fusion.drv' failed to build
+```
+
+We have provided a runnable invoked with `nix run .#print-checksums` to output the set of checksums to replace the existing ones with. These can be added into the relevant string fields of `./nix/helix-core-api.nix`.
+
+To check that the checksums are valid, you can run `nix run .#check-checksums`, which will quickly error out as above if any mismatches occur.
+
+### nix build fails while compiling/linking p4-fusion or any dependencies
+
+Please reach out to [#discuss-dev-infra](https://sourcegraph.slack.com/archives/C04MYFW01NV) to have someone take over (or pair with you if you're interested). If you want to take a stab at it (for the dopamine hit), be sure to not spend too long at it before asking for help!

--- a/nix/binary.nix
+++ b/nix/binary.nix
@@ -1,0 +1,97 @@
+{ callPackage
+, cmake
+, darwin
+, helix-core-api-set
+, hostPlatform
+, http-parser
+, lib
+, libiconv
+, openssl
+, overrideSDK
+, patchelf
+, pcre
+, pkg-config
+, stdenv
+, zlib
+}:
+let
+  inherit (callPackage ./util.nix { }) unNixifyDylibs;
+  # at the time of writing, there is an SDK version issue when building on
+  # x86_64-darwin, so we force it to 11.0.
+  # in future nixpkgs version, SDK versions should be better and more
+  #  consistently configured.
+  stdenv' = (if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv);
+in
+unNixifyDylibs (stdenv'.mkDerivation rec {
+  name = "p4-fusion";
+  version = "v1.13.2-sg";
+
+  srcs = [
+    (lib.sources.cleanSource ../.)
+    (helix-core-api-set.${hostPlatform.system})
+  ];
+
+  sourceRoot = "source";
+
+  # copy helix-core-api stuff into the expected directories, and statically link libstdc++
+  postUnpack = let dir = if hostPlatform.isMacOS then "mac" else "linux"; in ''
+    mkdir -p $sourceRoot/vendor/helix-core-api/${dir}
+    cp -R helix-core-api/* $sourceRoot/vendor/helix-core-api/${dir}
+  ''
+  # some extra cmake instructions to statically link libstdc++
+  + lib.optionalString hostPlatform.isStatic ''
+    substituteInPlace $sourceRoot/p4-fusion/CMakeLists.txt \
+      --replace 'target_link_libraries(p4-fusion PUBLIC' \
+                'target_link_libraries(p4-fusion PUBLIC -static-libstdc++'
+  '';
+
+  # on macos only it doesnt pick up sqlite + curl (and also depends on some lua stuff that it can't find?)
+  # so we'll just use the p4 provided ones. Passing `-lsqlite3 -lcurl` solves sqlite and curl, but not lua.
+  postPatch = lib.optionalString hostPlatform.isMacOS ''
+    substituteInPlace p4-fusion/CMakeLists.txt \
+      --replace 'p4script_c' 'p4script_c p4script_sqlite p4script_curl'
+  '';
+
+  nativeBuildInputs = [
+    patchelf
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    zlib
+    http-parser
+    pcre
+    openssl
+  ] ++ lib.optionals hostPlatform.isMacOS [
+    # iconv is bundled with glibc and apparently only needed for osx
+    # https://sourcegraph.com/github.com/sourcegraph/p4-fusion@82289290c68a3d2b5d3f4adc9db1cadd686cfcef/-/blob/vendor/libgit2/README.md?L178:3
+    libiconv
+    darwin.apple_sdk.frameworks.CFNetwork
+    darwin.apple_sdk.frameworks.Cocoa
+  ];
+
+  cmakeFlags = [
+    # Copied from upstream, where relevant
+    # https://sourcegraph.com/github.com/sourcegraph/p4-fusion@82289290c68a3d2b5d3f4adc9db1cadd686cfcef/-/blob/generate_cache.sh?L7-21
+    "-DUSE_SSH=OFF"
+    "-DUSE_HTTPS=OFF"
+    "-DBUILD_CLAR=OFF"
+    # salesforce don't link against GSSAPI in CI, so I won't either
+    "-DUSE_GSSAPI=OFF"
+    # prefer nix-provided http-parser instead of bundled
+    "-DUSE_HTTP_PARSER=system"
+  ] ++ lib.optional hostPlatform.isStatic "-DBUILD_SHARED_LIBS=OFF";
+
+  postInstall = ''
+    mkdir -p $out/bin
+    cp p4-fusion/p4-fusion $out/bin/p4-fusion
+    ln -s $out/bin/p4-fusion $out/bin/p4-fusion-${version}
+  '';
+
+  meta = {
+    homepage = "https://github.com/sourcegraph/p4-fusion";
+    platforms = [ "x86_64-darwin" "aarch64-darwin" "x86_64-linux" ];
+    license = lib.licenses.bsd3;
+  };
+})

--- a/nix/checksum-printer-script.nix
+++ b/nix/checksum-printer-script.nix
@@ -1,0 +1,15 @@
+{ pkgs, lib }:
+let
+  helix-core-api-set = pkgs.callPackage ./helix-core-api.nix { };
+  # we could provide printf/echo and nix/nix-prefetch-url here, but these are surely installed.
+  echo-hash = system: openssl_version: url: ''
+    HASH=$(nix hash to-sri "sha256:$(nix-prefetch-url --type sha256 --unpack ${url} 2>/dev/null)")
+    printf '%15s %s: %s\n' "${system}" "openssl ${openssl_version}" $HASH
+  '';
+in
+''
+  echo 'Update the relevant hashes in nix/helix-core-api.nix with these values:'
+'' + lib.concatLines (
+  lib.mapAttrsToList (name: value: echo-hash name "1.1" value.url) helix-core-api-set."1.1"
+  ++ lib.mapAttrsToList (name: value: echo-hash name "3.0" value.url) helix-core-api-set."3.0"
+)

--- a/nix/helix-core-api.nix
+++ b/nix/helix-core-api.nix
@@ -1,0 +1,37 @@
+{ fetchzip }:
+{
+  "1.1" = {
+    aarch64-darwin = fetchzip {
+      name = "helix-core-api";
+      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl1.1.1.tgz";
+      hash = "sha256-gblxNxyvjGHmrE54178JN4NTvI2EW3a58Yj7KngEr1o=";
+    };
+    x86_64-darwin = fetchzip {
+      name = "helix-core-api";
+      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl1.1.1.tgz";
+      hash = "sha256-9H0qbYU9yFcdqooLvXSkqYIiYIX9d+BaSh9dlMo1D5Q=";
+    };
+    x86_64-linux = fetchzip {
+      name = "helix-core-api";
+      url = "https://cdist2.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz";
+      hash = "sha256-SBeHjVuodRlLmAYA7/5qSASmneKaa7acXvhEPTxQd/w=";
+    };
+  };
+  "3.0" = {
+    aarch64-darwin = fetchzip {
+      name = "helix-core-api";
+      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl3.tgz";
+      hash = "sha256-s75750zXUxLbx3Bs2kjtGTKI1sKHO+tAQTF2d0dc234=";
+    };
+    x86_64-darwin = fetchzip {
+      name = "helix-core-api";
+      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl3.tgz";
+      hash = "sha256-uCR91Kbidq8DyJSw+Dpmiyn66LIkveNHZFwCfbBZ6dk=";
+    };
+    x86_64-linux = fetchzip {
+      name = "helix-core-api";
+      url = "https://cdist2.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz";
+      hash = "sha256-JaFjUjJP1GQ4iFCtuWbhYNonH3PiNlgI0z2L6UsN1JE=";
+    };
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,30 @@
+{ lib
+, zlib
+, http-parser
+, pcre
+, openssl
+, libiconv
+, mkShell
+, hostPlatform
+, patchelf
+, cmake
+, pkg-config
+, darwin
+}:
+mkShell {
+  name = "p4-fusion";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    zlib
+    http-parser
+    pcre
+    openssl
+    patchelf
+  ] ++ lib.optional hostPlatform.isMacOS [
+    libiconv
+    darwin.apple_sdk.frameworks.CFNetwork
+    darwin.apple_sdk.frameworks.Cocoa
+  ];
+}

--- a/nix/static-deps.nix
+++ b/nix/static-deps.nix
@@ -1,0 +1,37 @@
+{ callPackage
+, http-parser
+, lib
+, libiconv
+, openssl
+, openssl_1_1
+, pcre
+, zlib
+}:
+let
+  inherit (callPackage ./util.nix { }) mkStatic;
+in
+{
+  http-parser = (mkStatic http-parser).overrideAttrs (oldAttrs: {
+    # needed until upstream PR hits nixpkgs-unstable,
+    # track https://nixpk.gs/pr-tracker.html?pr=254516.
+    # http-parser makefile is a bit incomplete, so fill in the gaps here
+    # to move the static object and header files to the right location
+    # https://github.com/nodejs/http-parser/issues/310.
+    buildFlags = [ "package" ];
+    installTargets = "package";
+    postInstall = ''
+      install -D libhttp_parser.a $out/lib/libhttp_parser.a
+      install -D  http_parser.h $out/include/http_parser.h
+      ls -la $out/lib $out/include
+    '';
+  });
+
+  libiconv = mkStatic libiconv;
+  openssl = mkStatic openssl;
+  openssl_1_1 = mkStatic openssl_1_1;
+  pcre = mkStatic pcre;
+  # zlib.static only exists in `x86_64-darwin.pkgs.zlib`, after 
+  # https://github.com/NixOS/nixpkgs/pull/256590 `pkgsStatic.zlib`
+  # should work as expected.
+  zlib = (zlib.static or zlib);
+}

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -1,0 +1,46 @@
+# yoinked from https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/nix/util.nix
+{ lib, pkgs }:
+{
+  # utility function to add some best-effort flags for emitting static objects instead of dynamic.
+  # needed until https://github.com/NixOS/nixpkgs/pull/256590 makes pkgsStatic != pkgs in darwin.
+  mkStatic = drv:
+    assert lib.assertMsg (lib.isDerivation drv) "mkStatic expects a derivation, got ${builtins.typeOf drv}";
+    assert lib.assertMsg (drv ? "overrideAttrs") "mkStatic expects an overridable derivation";
+
+    let
+      auto = builtins.intersectAttrs drv.override.__functionArgs { withStatic = true; static = true; enableStatic = true; enableShared = false; };
+      overridden = drv.overrideAttrs (oldAttrs: {
+        dontDisableStatic = true;
+      } // lib.optionalAttrs (!(oldAttrs.dontAddStaticConfigureFlags or false)) {
+        configureFlags = (oldAttrs.configureFlags or [ ]) ++ [ "--disable-shared" "--enable-static" "--enable-shared=false" ];
+      });
+    in
+    if drv.pname == "openssl" then drv.override { static = true; } else overridden.override auto;
+
+  # doesn't actually change anything in practice, just makes otool -L not display nix store paths for dynamic libraries.
+  # these are expected to exist in macos dydl cache anyways, so where they point to is irrelevant. worst case, this will let 
+  # you catch earlier when a library that should be statically linked, or that isnt in dydl cache, is dynamically linked.
+  unNixifyDylibs = drv:
+    assert lib.assertMsg (lib.isDerivation drv) "unNixifyDylibs expects a derivation, got ${builtins.typeOf drv}";
+    assert lib.assertMsg (drv ? "overrideAttrs") "unNixifyDylibs expects an overridable derivation";
+
+    drv.overrideAttrs (oldAttrs: lib.optionalAttrs pkgs.hostPlatform.isMacOS {
+      nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++
+        map (drv: drv.__spliced.buildHost or drv)
+          (with (pkgs.__splicedPackages or pkgs); [
+            findutils
+            darwin.cctools
+            coreutils
+            gnugrep
+          ]);
+
+      postFixup = (oldAttrs.postFixup or "") + ''
+        for bin in $(find $out/bin -type f); do
+          for lib in $(otool -L $bin | tail -n +2 | cut -d' ' -f1 | grep nix); do
+            echo "patching dylib from "$lib" to "@rpath/$(basename $lib)""
+            install_name_tool -change "$lib" "@rpath/$(basename $lib)" $bin
+          done
+        done
+      '';
+    });
+}


### PR DESCRIPTION
Like with [universal-ctags in sg/sg](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/.github/workflows/universal-ctags.yml), we want to provision p4-fusion binaries via Bazel. 

We do this through GHA workflows to build in PRs and build+upload on commits to main. A [brief explanatory readme](https://github.com/sourcegraph/p4-fusion/pull/28/files#diff-289607d0f22afc0a39c2c7c2300810a476a72bcf0f5c494e62663d76e00d8531) with some basic troubleshooting tips is included (please feel free to propose any other additions to it) along with, what is hopefully, plenty of in-code documentation on some points of note/workarounds/other commentary (again, feel free to probe on anything that stands out/needs further explanation)

## Test plan

Mucho testing of the GHA workflows (see e.g. https://github.com/sourcegraph/p4-fusion/actions/runs/7146415735?pr=28)
