### PR TITLE
chore: use filehost.perforce.com instead of cdist2.perforce.com

### DIFF
--- a/.github/workflows/validate-migration.yaml
+++ b/.github/workflows/validate-migration.yaml
@@ -8,7 +8,7 @@ concurrency:
 
 env:
   # Setup: Constants for downloading and compiling dependencies
-  P4_DOWNLOAD_URL: "https://cdist2.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz"
+  P4_DOWNLOAD_URL: "https://filehost.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz"
   P4_DOWNLOAD_DIR: "/tmp/p4-download"
 
   OPENSSL_DOWNLOAD_URL: "https://www.openssl.org/source/openssl-1.1.1w.tar.gz"

--- a/nix/helix-core-api.nix
+++ b/nix/helix-core-api.nix
@@ -3,35 +3,35 @@
   "1.1" = {
     aarch64-darwin = fetchzip {
       name = "helix-core-api";
-      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl1.1.1.tgz";
-      hash = "sha256-MiRKvW/IbA1AcNpFWCIBGsYomelCLrTU04+Vq5yyUVI=";
+      url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl1.1.1.tgz";
+      hash = "sha256-9jyecw8S98nKRy3mehrMlndaggu3suEyQIZq8pz+dX0=";
     };
     x86_64-darwin = fetchzip {
       name = "helix-core-api";
-      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl1.1.1.tgz";
-      hash = "sha256-QF69oWI8qqST9ELJrEzx4pFQik/RsEmsRVq7EOo5gt0=";
+      url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl1.1.1.tgz";
+      hash = "sha256-a+4dovGVvqH1Kyon8m8j319iYlDRriU2BraCbxCgL0U=";
     };
     x86_64-linux = fetchzip {
       name = "helix-core-api";
-      url = "https://cdist2.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz";
-      hash = "sha256-R8oP1uJ70J2XRToLAPAVKxU/VEr2e6LlaR3zn21lKaI=";
+      url = "https://filehost.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz";
+      hash = "sha256-p7NJlpLmI/w7XA6uaGuIluwtJx96aTCUebrTj9M6wyI=";
     };
   };
   "3.0" = {
     aarch64-darwin = fetchzip {
       name = "helix-core-api";
-      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl3.tgz";
-      hash = "sha256-SVAw1ADhd7pwgHprE+J61bp5AiP9ULCw64WeN5MVV9M=";
+      url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl3.tgz";
+      hash = "sha256-cTSy1uy6IxhFqOD3ZSkbj6aDXizg8MuiHQoi4wOsngo=";
     };
     x86_64-darwin = fetchzip {
       name = "helix-core-api";
-      url = "https://cdist2.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl3.tgz";
-      hash = "sha256-HhSmQWfX9yh734FtG14BzIQY9YliAH9kV5RaQ71T0RU=";
+      url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl3.tgz";
+      hash = "sha256-KEUVsc6fwQEA45ShG3rbaVEY4gDmS5GB+RCwcL5bIiU=";
     };
     x86_64-linux = fetchzip {
       name = "helix-core-api";
-      url = "https://cdist2.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz";
-      hash = "sha256-oJzHuq8/9PgGi6e1/bxXuaZER5+DR5tmCIN21/fVImQ=";
+      url = "https://filehost.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz";
+      hash = "sha256-1iPHQXGSnelLJRo8RdTVDEpb80G1bcNsLWuvf4aHW+g=";
     };
   };
 }


### PR DESCRIPTION
After our discovery that cdist2 appears to create weird SHA sums and filehost doesnt, lets migrate over

See https://github.com/sourcegraph/sourcegraph/pull/60784

## Test plan

CI
