### PR TITLE
Fix openssl build error

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <code_scheme name="Project" version="173">
-    <clangFormatSettings>
-      <option name="ENABLED" value="true" />
-    </clangFormatSettings>
-  </code_scheme>
-</component>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <clangFormatSettings>
+      <option name="ENABLED" value="true" />
+    </clangFormatSettings>
+  </code_scheme>
+</component>

--- a/generate_cache.sh
+++ b/generate_cache.sh
@@ -17,7 +17,6 @@ cmakeArgs=(
   -DUSE_SSH=OFF
   -DUSE_HTTPS=OFF
   -DUSE_THREADS=ON
-  -DOPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-"/usr/local/ssl"}"
   -DCMAKE_C_COMPILER="${CMAKE_C_COMPILER:-"/usr/bin/gcc"}"
   -DCMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER:-"/usr/bin/g++"}"
 )
@@ -53,6 +52,12 @@ fi
 if [[ -n "$CMAKE_CXX_COMPILER_LAUNCHER" ]]; then
   cmakeArgs+=(
     -DCMAKE_CXX_COMPILER_LAUNCHER="$CMAKE_CXX_COMPILER_LAUNCHER"
+  )
+fi
+
+if [[ -n "$OPENSSL_ROOT_DIR" ]]; then
+  cmakeArgs+=(
+    -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR"
   )
 fi
 


### PR DESCRIPTION
The `-DOPENSSL_ROOT_DIR` flag overrides the check done in the CMakeLists.txt file, leading to builds failing on MacOS.

This PR makes it so that the flag is only added if the envvar is explicitly set.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
