### PR TITLE
update p4-fusion sha

### DIFF
--- a/nix/helix-core-api.nix
+++ b/nix/helix-core-api.nix
@@ -4,34 +4,34 @@
     aarch64-darwin = fetchzip {
       name = "helix-core-api";
       url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl1.1.1.tgz";
-      hash = "sha256-0jU51a239Ul5hicoCYhlzc6CmFXXWqlHEv2CsTYarS0=";
+      hash = "sha256-nS86Qxm+qoDCTlIm7cEb+AyhLpa/eusOPsQtk71KAQk=";
     };
     x86_64-darwin = fetchzip {
       name = "helix-core-api";
       url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl1.1.1.tgz";
-      hash = "sha256-a+4dovGVvqH1Kyon8m8j319iYlDRriU2BraCbxCgL0U=";
+      hash = "sha256-go7uhe6eAX+rnnn5zzmKPya93ZK65q6bL0nsDXLx0ZA=";
     };
     x86_64-linux = fetchzip {
       name = "helix-core-api";
       url = "https://filehost.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.1.1.tgz";
-      hash = "sha256-OfVxND14LpgujJTl9WfhsHdPsZ/INd9iDw5DcyzglLU=";
+      hash = "sha256-mgEsUCrbT6xvWUjcRnG8ALEYGV3GpCCPNprjoTG+xbc=";
     };
   };
   "3.0" = {
     aarch64-darwin = fetchzip {
       name = "helix-core-api";
       url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12arm64/p4api-openssl3.tgz";
-      hash = "sha256-cTSy1uy6IxhFqOD3ZSkbj6aDXizg8MuiHQoi4wOsngo=";
+      hash = "sha256-dCeOGcJ3+wHwFFL03J+KwpDHB+Kx0IdQxJ82IBScJXA=";
     };
     x86_64-darwin = fetchzip {
       name = "helix-core-api";
       url = "https://filehost.perforce.com/perforce/r23.1/bin.macosx12x86_64/p4api-openssl3.tgz";
-      hash = "sha256-KEUVsc6fwQEA45ShG3rbaVEY4gDmS5GB+RCwcL5bIiU=";
+      hash = "sha256-esmStuzKcpLcw18pTzsR1ZQUfoEqLhOw0yIZxFFlgu0=";
     };
     x86_64-linux = fetchzip {
       name = "helix-core-api";
       url = "https://filehost.perforce.com/perforce/r23.1/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz";
-      hash = "sha256-1iPHQXGSnelLJRo8RdTVDEpb80G1bcNsLWuvf4aHW+g=";
+      hash = "sha256-OAR11FKkulpoReMGnDQwFOeJtF+WA/4lxWMqrSNiLPI=";
     };
   };
 }


### PR DESCRIPTION
Update the shas as directed by `nix run '.#print-checksums'`
## Test plan
```
p4-fusion on  master [!] via △
❯ nix build '.#p4-fusion_openssl1_1'
warning: Git tree '/Users/william/code/p4-fusion' is dirty

p4-fusion on  master [!] via △ took 1m5s
❯ nix build '.#p4-fusion_openssl3'
warning: Git tree '/Users/william/code/p4-fusion' is dirty

p4-fusion on  master [!] via △ took 57s
```
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
