### PR TITLE
fix nix derivations for macos builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702539185,
-        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
+        "lastModified": 1724208548,
+        "narHash": "sha256-8Aiur5lv2L8o9ErxHqS2F293MHiHCoRG8C4vCwhkeXo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
+        "rev": "4c30668e1edb7348169407f218fa7c71a94b17f3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,8 @@
           # but apply them to every system type as it doesn't harm them anyway.
           # note also a http-parser workaround detailed in the below file.
           static-deps-set = pkgsStatic.callPackage ./nix/static-deps.nix { };
+          
+          inherit (pkgs.callPackage ./nix/util.nix { }) unNixifyDylibs;
         in
         {
           p4-fusion_openssl3 = pkgs.callPackage ./nix/binary.nix {
@@ -41,16 +43,18 @@
             helix-core-api-set = helix-core-api-set."1.1";
           };
 
-          p4-fusion_openssl3-static = pkgsStatic.callPackage ./nix/binary.nix {
+          p4-fusion_openssl3-static = unNixifyDylibs (pkgsStatic.callPackage ./nix/binary.nix {
+            darwin = pkgs.darwin or null;
             inherit (static-deps-set) http-parser libiconv openssl pcre zlib;
             helix-core-api-set = helix-core-api-set."3.0";
-          };
+          });
 
-          p4-fusion_openssl1_1-static = pkgsStatic.callPackage ./nix/binary.nix {
+          p4-fusion_openssl1_1-static = unNixifyDylibs (pkgsStatic.callPackage ./nix/binary.nix {
             openssl = static-deps-set.openssl_1_1;
+            darwin = pkgs.darwin or null;
             inherit (static-deps-set) http-parser libiconv pcre zlib;
             helix-core-api-set = helix-core-api-set."1.1";
-          };
+          });
         });
 
       apps = forAllSystems (pkgs:

--- a/nix/binary.nix
+++ b/nix/binary.nix
@@ -1,5 +1,4 @@
-{ callPackage
-, cmake
+{ cmake
 , darwin
 , helix-core-api-set
 , hostPlatform
@@ -15,14 +14,13 @@
 , zlib
 }:
 let
-  inherit (callPackage ./util.nix { }) unNixifyDylibs;
   # at the time of writing, there is an SDK version issue when building on
   # x86_64-darwin, so we force it to 11.0.
   # in future nixpkgs version, SDK versions should be better and more
   #  consistently configured.
   stdenv' = (if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv);
 in
-unNixifyDylibs (stdenv'.mkDerivation rec {
+stdenv'.mkDerivation rec {
   name = "p4-fusion";
   version = "v1.13.2-sg";
 
@@ -94,4 +92,4 @@ unNixifyDylibs (stdenv'.mkDerivation rec {
     platforms = [ "x86_64-darwin" "aarch64-darwin" "x86_64-linux" ];
     license = lib.licenses.bsd3;
   };
-})
+}


### PR DESCRIPTION
Some codesign issue, not sure whats up, but i think a newer nixpkgs version fixed it. Some misc fixes along the way (unNixifyDylibs stopped working apparently? I swear it worked as-is before) 

## Test plan

`nix build .#p4-fusion_openssl1_1-static && ./result/bin/p4-fusion`
