### PR TITLE
Add Perforce label caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ These execution times are expected to scale as expected with larger depots (mill
 --noConvertLabels [Optional, Default is false]
         Whether or not to disable label to tag conversion.
 
+--labelCache [Optional]
+        Absolute path to a label cache file. If not specified, labels will not be cached.
+
 --src [Required]
         Relative path where the git repository should be created. This path should be empty before running p4-fusion for the first time in a directory.
 

--- a/p4-fusion/commands/label_result.cc
+++ b/p4-fusion/commands/label_result.cc
@@ -19,6 +19,7 @@ void LabelResult::OutputStat(StrDict* varList)
 
 	StrPtr* revisionPtr = varList->GetVar("Revision");
 	StrPtr* descriptionPtr = varList->GetVar("Description");
+	StrPtr* updatePtr = varList->GetVar("Update");
 
 	label = labelPtr->Text();
 
@@ -29,6 +30,10 @@ void LabelResult::OutputStat(StrDict* varList)
 	if (descriptionPtr)
 	{
 		description = descriptionPtr->Text();
+	}
+	if (updatePtr)
+	{
+		update = updatePtr->Text();
 	}
 
 	int i = 0;

--- a/p4-fusion/commands/label_result.h
+++ b/p4-fusion/commands/label_result.h
@@ -15,7 +15,7 @@ public:
 	std::string label;
 	std::string revision;
 	std::string description;
-	std::string update;
+	std::string update; // Last updated at time in yyyy/mm/dd hh:mm:ss
 	std::vector<std::string> views;
 
 public:

--- a/p4-fusion/commands/label_result.h
+++ b/p4-fusion/commands/label_result.h
@@ -15,6 +15,7 @@ public:
 	std::string label;
 	std::string revision;
 	std::string description;
+	std::string update;
 	std::vector<std::string> views;
 
 public:

--- a/p4-fusion/commands/labels_result.cc
+++ b/p4-fusion/commands/labels_result.cc
@@ -9,6 +9,7 @@
 void LabelsResult::OutputStat(StrDict* varList)
 {
 	StrPtr* labelIDPtr = varList->GetVar("label");
+	StrPtr* updatePtr = varList->GetVar("Update");
 
 	if (!labelIDPtr)
 	{
@@ -17,5 +18,5 @@ void LabelsResult::OutputStat(StrDict* varList)
 		return;
 	}
 
-	m_Labels.emplace_back(labelIDPtr->Text());
+	m_Labels.emplace_back(LabelsResult::LabelData { .label = labelIDPtr->Text(), .update = updatePtr->Text() });
 }

--- a/p4-fusion/commands/labels_result.h
+++ b/p4-fusion/commands/labels_result.h
@@ -15,7 +15,7 @@ public:
 	struct LabelData
 	{
 		std::string label;
-		std::string update;
+		std::string update; // Last updated at timestamp in unix time
 	};
 
 private:

--- a/p4-fusion/commands/labels_result.h
+++ b/p4-fusion/commands/labels_result.h
@@ -6,16 +6,23 @@
  */
 #pragma once
 
-#include "common.h"
 #include "result.h"
 #include <list>
 
 class LabelsResult : public Result
 {
-	std::list<std::string> m_Labels;
+public:
+	struct LabelData
+	{
+		std::string label;
+		std::string update;
+	};
+
+private:
+	std::list<LabelData> m_Labels;
 
 public:
-	[[nodiscard]] const std::list<std::string>& GetLabels() const { return m_Labels; }
+	[[nodiscard]] const std::list<LabelsResult::LabelData>& GetLabels() const { return m_Labels; }
 
 	void OutputStat(StrDict* varList) override;
 };

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -420,11 +420,11 @@ void GitAPI::CreateTagsFromLabels(LabelMap revToLabel)
 	git_reference* ref;
 	while (git_reference_next(&ref, refIter) >= 0)
 	{
-		std::string labelName = trimPrefix(git_reference_name(ref), "refs/tags/");
+		std::string labelName = trim_prefix(git_reference_name(ref), "refs/tags/");
 
 		git_commit* commit;
 		checkGit2Error(git_commit_lookup(&commit, m_Repo, git_reference_target(ref)));
-		if (std::string cl = getChangelistFromCommit(commit); revToLabel.contains(cl) && revToLabel.at(cl)->contains(labelName))
+		if (std::string cl = get_changelist_from_commit(commit); revToLabel.contains(cl) && revToLabel.at(cl)->contains(labelName))
 		{
 			revToLabel.at(cl)->erase(labelName);
 			if (revToLabel.at(cl)->empty())
@@ -456,15 +456,15 @@ void GitAPI::CreateTagsFromLabels(LabelMap revToLabel)
 
 	while (true)
 	{
-		std::string clID = getChangelistFromCommit(current_commit);
+		std::string clID = get_changelist_from_commit(current_commit);
 		if (revToLabel.contains(clID))
 		{
 			for (auto& [_, v] : *revToLabel.at(clID))
 			{
 
-				PRINT("TAG:" << convertLabelToTag(v.label) << ":" << v.label)
+				PRINT("TAG:" << convert_label_to_tag(v.label) << ":" << v.label)
 				git_reference* tmpref;
-				checkGit2Error(git_reference_create(&tmpref, m_Repo, ("refs/tags/" + convertLabelToTag(v.label)).c_str(), git_commit_id(current_commit), false, v.description.c_str()));
+				checkGit2Error(git_reference_create(&tmpref, m_Repo, ("refs/tags/" + convert_label_to_tag(v.label)).c_str(), git_commit_id(current_commit), false, v.description.c_str()));
 				git_reference_free(tmpref);
 			}
 			delete revToLabel.at(clID);

--- a/p4-fusion/git_api.h
+++ b/p4-fusion/git_api.h
@@ -24,8 +24,6 @@ struct git_repository;
 // revision can have multiple labels associated with it.
 using LabelMap = std::unordered_map<std::string, std::unordered_map<std::string, LabelResult>*>;
 
-using LabelNameToDetails = std::unordered_map<std::string, LabelResult>;
-
 class BlobWriter
 {
 private:

--- a/p4-fusion/git_api.h
+++ b/p4-fusion/git_api.h
@@ -24,6 +24,8 @@ struct git_repository;
 // revision can have multiple labels associated with it.
 using LabelMap = std::unordered_map<std::string, std::unordered_map<std::string, LabelResult>*>;
 
+using LabelNameToDetails = std::unordered_map<std::string, LabelResult>;
+
 class BlobWriter
 {
 private:

--- a/p4-fusion/labels_cache.cc
+++ b/p4-fusion/labels_cache.cc
@@ -1,5 +1,12 @@
 #include "labels_cache.h"
 
+const int LABEL_CACHE_VERSION = 1;
+
+void write_int(std::ofstream& outFile, const int number)
+{
+	outFile.write(reinterpret_cast<const char*>(&number), sizeof(number));
+}
+
 void write_string(std::ofstream& outFile, const std::string& str)
 {
 	size_t length = str.size();
@@ -19,6 +26,7 @@ void write_vector_of_strings(std::ofstream& outFile, const std::vector<std::stri
 
 void write_struct_to_disk(std::ofstream& outFile, const LabelResult& labels)
 {
+	write_int(outFile, LABEL_CACHE_VERSION); // Write a version number first
 	write_string(outFile, labels.label);
 	write_string(outFile, labels.revision);
 	write_string(outFile, labels.description);
@@ -48,6 +56,13 @@ void write_label_map_to_disk(const std::string& filename, const LabelNameToDetai
 	outFile.close();
 }
 
+int read_int(std::ifstream& inFile)
+{
+	int number;
+	inFile.read(reinterpret_cast<char*>(&number), sizeof(number));
+	return number;
+}
+
 std::string read_string(std::ifstream& inFile)
 {
 	size_t length;
@@ -72,6 +87,12 @@ std::vector<std::string> read_vector_of_strings(std::ifstream& inFile)
 LabelResult read_struct_from_disk(std::ifstream& inFile)
 {
 	LabelResult label;
+	int version = read_int(inFile);
+	if (version != LABEL_CACHE_VERSION)
+	{
+		ERR("Incorrect label version!")
+		return label;
+	}
 	label.label = read_string(inFile);
 	label.revision = read_string(inFile);
 	label.description = read_string(inFile);

--- a/p4-fusion/labels_cache.cc
+++ b/p4-fusion/labels_cache.cc
@@ -108,7 +108,7 @@ LabelNameToDetails readLabelMapFromDisk(const std::string& filename)
 // Compares the last updated date in the labels list to the updated dates
 // in the cache, and returns all labels of which the last updated date is
 // different.
-compareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap)
+CompareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap)
 {
 	LabelNameToDetails newLabelMap;
 	std::list<LabelsResult::LabelData> labelsToFetch;
@@ -133,7 +133,7 @@ compareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& l
 		}
 	}
 
-	return compareResponse {
+	return CompareResponse {
 		.labelsToFetch = labelsToFetch,
 		.resultingLabels = newLabelMap
 	};

--- a/p4-fusion/labels_cache.cc
+++ b/p4-fusion/labels_cache.cc
@@ -1,0 +1,140 @@
+#include "labels_cache.h"
+
+void writeString(std::ofstream& outFile, const std::string& str)
+{
+	size_t length = str.size();
+	outFile.write(reinterpret_cast<const char*>(&length), sizeof(length));
+	outFile.write(str.data(), length);
+}
+
+void writeVectorOfStrings(std::ofstream& outFile, const std::vector<std::string>& vec)
+{
+	size_t vecSize = vec.size();
+	outFile.write(reinterpret_cast<const char*>(&vecSize), sizeof(vecSize));
+	for (const auto& str : vec)
+	{
+		writeString(outFile, str);
+	}
+}
+
+void writeStructToDisk(std::ofstream& outFile, const LabelResult& labels)
+{
+	writeString(outFile, labels.label);
+	writeString(outFile, labels.revision);
+	writeString(outFile, labels.description);
+	writeString(outFile, labels.update);
+	writeVectorOfStrings(outFile, labels.views);
+}
+
+void writeLabelMapToDisk(const std::string& filename, const LabelNameToDetails& labelMap, const std::string& cacheFile)
+{
+	std::ofstream outFile(filename, std::ios::binary);
+	if (!outFile)
+	{
+		ERR("Error opening " << cacheFile << " file for writing, could not cache labels!");
+		return;
+	}
+
+	// Write the size of the map
+	size_t size = labelMap.size();
+	outFile.write(reinterpret_cast<const char*>(&size), sizeof(size));
+
+	// Write each key-value pair
+	for (const auto& pair : labelMap)
+	{
+		writeStructToDisk(outFile, pair.second);
+	}
+
+	outFile.close();
+}
+
+std::string readString(std::ifstream& inFile)
+{
+	size_t length;
+	inFile.read(reinterpret_cast<char*>(&length), sizeof(length));
+	std::string str(length, '\0');
+	inFile.read(&str[0], length);
+	return str;
+}
+
+std::vector<std::string> readVectorOfStrings(std::ifstream& inFile)
+{
+	size_t vecSize;
+	inFile.read(reinterpret_cast<char*>(&vecSize), sizeof(vecSize));
+	std::vector<std::string> vec(vecSize);
+	for (size_t i = 0; i < vecSize; ++i)
+	{
+		vec[i] = readString(inFile);
+	}
+	return vec;
+}
+
+LabelResult readStructFromDisk(std::ifstream& inFile)
+{
+	LabelResult label;
+	label.label = readString(inFile);
+	label.revision = readString(inFile);
+	label.description = readString(inFile);
+	label.update = readString(inFile);
+	label.views = readVectorOfStrings(inFile);
+	return label;
+}
+
+LabelNameToDetails readLabelMapFromDisk(const std::string& filename)
+{
+	LabelNameToDetails labelMap;
+	std::ifstream inFile(filename, std::ios::binary);
+	if (!inFile)
+	{
+		ERR("No label cache found at " << filename)
+		return labelMap;
+	}
+
+	// Read the size of the map
+	size_t size;
+	inFile.read(reinterpret_cast<char*>(&size), sizeof(size));
+
+	// Read each key-value pair and insert into the map
+	for (size_t i = 0; i < size; ++i)
+	{
+		LabelResult value = readStructFromDisk(inFile);
+		labelMap.insert({ value.label, value });
+	}
+
+	inFile.close();
+	return labelMap;
+}
+
+// Compares the last updated date in the labels list to the updated dates
+// in the cache, and returns all labels of which the last updated date is
+// different.
+compareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap)
+{
+	LabelNameToDetails newLabelMap;
+	std::list<LabelsResult::LabelData> labelsToFetch;
+	for (const auto& label : labels)
+	{
+		if (labelMap.contains(label.label))
+		{
+			LabelResult cachedLabel
+			    = labelMap.at(label.label);
+			if (cachedLabel.update != label.update)
+			{
+				labelsToFetch.push_back(label);
+			}
+			else
+			{
+				newLabelMap.insert({ label.label, cachedLabel });
+			}
+		}
+		else
+		{
+			labelsToFetch.push_back(label);
+		}
+	}
+
+	return compareResponse {
+		.labelsToFetch = labelsToFetch,
+		.resultingLabels = newLabelMap
+	};
+}

--- a/p4-fusion/labels_cache.h
+++ b/p4-fusion/labels_cache.h
@@ -7,7 +7,7 @@
 struct compareResponse
 {
 	std::list<LabelsResult::LabelData> labelsToFetch;
-	LabelNameToDetails resultingLabels; // labelMap with the labels that no longer exit removed
+	LabelNameToDetails resultingLabels; // labelMap with the labels that no longer exist removed
 };
 
 void writeLabelMapToDisk(const std::string& filename, const LabelNameToDetails& labelMap, const std::string& cacheFile);

--- a/p4-fusion/labels_cache.h
+++ b/p4-fusion/labels_cache.h
@@ -1,0 +1,15 @@
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "labels_conversion.h"
+
+struct compareResponse
+{
+	std::list<LabelsResult::LabelData> labelsToFetch;
+	LabelNameToDetails resultingLabels; // labelMap with the labels that no longer exit removed
+};
+
+void writeLabelMapToDisk(const std::string& filename, const LabelNameToDetails& labelMap, const std::string& cacheFile);
+LabelNameToDetails readLabelMapFromDisk(const std::string& filename);
+compareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap);

--- a/p4-fusion/labels_cache.h
+++ b/p4-fusion/labels_cache.h
@@ -4,12 +4,12 @@
 
 #include "labels_conversion.h"
 
-struct compareResponse
+struct CompareResponse
 {
 	std::list<LabelsResult::LabelData> labelsToFetch;
 	LabelNameToDetails resultingLabels; // labelMap with the labels that no longer exist removed
 };
 
-void writeLabelMapToDisk(const std::string& filename, const LabelNameToDetails& labelMap, const std::string& cacheFile);
-LabelNameToDetails readLabelMapFromDisk(const std::string& filename);
-compareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap);
+void write_label_map_to_disk(const std::string& filename, const LabelNameToDetails& labelMap, const std::string& cacheFile);
+LabelNameToDetails read_label_map_from_disk(const std::string& filename);
+CompareResponse compare_labels_to_cache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap);

--- a/p4-fusion/labels_conversion.cc
+++ b/p4-fusion/labels_conversion.cc
@@ -6,6 +6,8 @@
 #include "git2/commit.h"
 #include "git2/types.h"
 
+#include "labels_conversion.h"
+
 // sanitizeLabelName removes characters from a label name that
 // aren't valid in git tags as specified by
 // https://git-scm.com/docs/git-check-ref-format
@@ -120,7 +122,9 @@ std::string getChangelistFromCommit(const git_commit* commit)
 	return cl;
 }
 
-LabelNameToDetails getLabelsDetails2(P4API* p4, std::list<LabelsResult::LabelData> labels)
+// Fetch the details of a list of labels. This will make requests
+// to the Perforce server equal to the number of labels in the list
+LabelNameToDetails getLabelsDetails(P4API* p4, std::list<LabelsResult::LabelData> labels)
 {
 	LabelNameToDetails labelMap;
 

--- a/p4-fusion/labels_conversion.cc
+++ b/p4-fusion/labels_conversion.cc
@@ -17,7 +17,7 @@
 // This function was LLM generated and the regex checked with
 // https://regex101.com/ . Seems to make sense, and tested
 // with a few label names.
-std::string convertLabelToTag(std::string input)
+std::string convert_label_to_tag(std::string input)
 {
 	std::string result = input;
 
@@ -89,7 +89,7 @@ std::string trimSuffix(const std::string& str, const std::string& suffix)
 }
 
 // Trim the specified prefix from the string
-std::string trimPrefix(const std::string& str, const std::string& prefix)
+std::string trim_prefix(const std::string& str, const std::string& prefix)
 {
 	if (str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0)
 	{
@@ -98,7 +98,7 @@ std::string trimPrefix(const std::string& str, const std::string& prefix)
 	return str;
 }
 
-std::string getChangelistFromCommit(const git_commit* commit)
+std::string get_changelist_from_commit(const git_commit* commit)
 {
 	// Look for the specific change message generated from the Commit method.
 	// Note that extra branching information can be added after it.
@@ -124,7 +124,7 @@ std::string getChangelistFromCommit(const git_commit* commit)
 
 // Fetch the details of a list of labels. This will make requests
 // to the Perforce server equal to the number of labels in the list
-LabelNameToDetails getLabelsDetails(P4API* p4, std::list<LabelsResult::LabelData> labels)
+LabelNameToDetails get_labels_details(P4API* p4, std::list<LabelsResult::LabelData> labels)
 {
 	LabelNameToDetails labelMap;
 
@@ -146,7 +146,7 @@ LabelNameToDetails getLabelsDetails(P4API* p4, std::list<LabelsResult::LabelData
 	return labelMap;
 }
 
-LabelMap labelDetailsToMap(std::string depotPath, LabelNameToDetails labels)
+LabelMap label_details_to_map(std::string depotPath, LabelNameToDetails labels)
 {
 	LabelMap revToLabel;
 
@@ -166,7 +166,7 @@ LabelMap labelDetailsToMap(std::string depotPath, LabelNameToDetails labels)
 				revToLabel.insert({ labelRes.revision, newMap });
 			}
 			auto res = revToLabel.at(labelRes.revision);
-			res->insert({ convertLabelToTag(labelRes.label), labelRes });
+			res->insert({ convert_label_to_tag(labelRes.label), labelRes });
 		}
 		else
 		{
@@ -180,7 +180,7 @@ LabelMap labelDetailsToMap(std::string depotPath, LabelNameToDetails labels)
 						revToLabel.insert({ labelRes.revision, newMap });
 					}
 					auto res = revToLabel.at(labelRes.revision);
-					res->insert({ convertLabelToTag(labelRes.label), labelRes });
+					res->insert({ convert_label_to_tag(labelRes.label), labelRes });
 				}
 			}
 		}

--- a/p4-fusion/labels_conversion.cc
+++ b/p4-fusion/labels_conversion.cc
@@ -142,9 +142,7 @@ LabelNameToDetails getLabelsDetails2(P4API* p4, std::list<LabelsResult::LabelDat
 	return labelMap;
 }
 
-// Fetches additional label details for each label using the provided p4 client
-// and returns a map of revision to label to label details.
-LabelMap getLabelsDetails(P4API* p4, std::string depotPath, LabelNameToDetails labels)
+LabelMap labelDetailsToMap(std::string depotPath, LabelNameToDetails labels)
 {
 	LabelMap revToLabel;
 

--- a/p4-fusion/labels_conversion.cc
+++ b/p4-fusion/labels_conversion.cc
@@ -122,13 +122,13 @@ std::string getChangelistFromCommit(const git_commit* commit)
 
 // Fetches additional label details for each label using the provided p4 client
 // and returns a map of revision to label to label details.
-LabelMap getLabelsDetails(P4API* p4, std::string depotPath, std::list<std::string> labels)
+LabelMap getLabelsDetails(P4API* p4, std::string depotPath, std::list<LabelsResult::LabelData> labels)
 {
 	LabelMap revToLabel;
 
 	for (auto& label : labels)
 	{
-		LabelResult labelRes = p4->Label(label);
+		LabelResult labelRes = p4->Label(label.label);
 		if (labelRes.HasError())
 		{
 			ERR("Failed to retrieve label details: " << labelRes.PrintError());

--- a/p4-fusion/labels_conversion.h
+++ b/p4-fusion/labels_conversion.h
@@ -6,10 +6,10 @@
 // A map from a label name to the details of the label
 using LabelNameToDetails = std::unordered_map<std::string, LabelResult>;
 
-std::string convertLabelToTag(std::string label);
-std::string trimPrefix(const std::string& str, const std::string& prefix);
-std::string getChangelistFromCommit(const git_commit* commit);
-LabelMap labelDetailsToMap(std::string depotPath, LabelNameToDetails labels);
-LabelNameToDetails getLabelsDetails(P4API* p4, std::list<LabelsResult::LabelData> labels);
+std::string convert_label_to_tag(std::string label);
+std::string trim_prefix(const std::string& str, const std::string& prefix);
+std::string get_changelist_from_commit(const git_commit* commit);
+LabelMap label_details_to_map(std::string depotPath, LabelNameToDetails labels);
+LabelNameToDetails get_labels_details(P4API* p4, std::list<LabelsResult::LabelData> labels);
 
 #endif // LABELS_CONVERSION_H

--- a/p4-fusion/labels_conversion.h
+++ b/p4-fusion/labels_conversion.h
@@ -3,10 +3,13 @@
 #include "commands/labels_result.h"
 #include "p4_api.h"
 
+// A map from a label name to the details of the label
+using LabelNameToDetails = std::unordered_map<std::string, LabelResult>;
+
 std::string convertLabelToTag(std::string label);
 std::string trimPrefix(const std::string& str, const std::string& prefix);
 std::string getChangelistFromCommit(const git_commit* commit);
 LabelMap labelDetailsToMap(std::string depotPath, LabelNameToDetails labels);
-LabelNameToDetails getLabelsDetails2(P4API* p4, std::list<LabelsResult::LabelData> labels);
+LabelNameToDetails getLabelsDetails(P4API* p4, std::list<LabelsResult::LabelData> labels);
 
 #endif // LABELS_CONVERSION_H

--- a/p4-fusion/labels_conversion.h
+++ b/p4-fusion/labels_conversion.h
@@ -6,7 +6,7 @@
 std::string convertLabelToTag(std::string label);
 std::string trimPrefix(const std::string& str, const std::string& prefix);
 std::string getChangelistFromCommit(const git_commit* commit);
-LabelMap getLabelsDetails(P4API* p4, std::string depotPath, LabelNameToDetails labels);
+LabelMap labelDetailsToMap(std::string depotPath, LabelNameToDetails labels);
 LabelNameToDetails getLabelsDetails2(P4API* p4, std::list<LabelsResult::LabelData> labels);
 
 #endif // LABELS_CONVERSION_H

--- a/p4-fusion/labels_conversion.h
+++ b/p4-fusion/labels_conversion.h
@@ -1,10 +1,11 @@
 #ifndef LABELS_CONVERSION_H
 #define LABELS_CONVERSION_H
+#include "commands/labels_result.h"
 #include "p4_api.h"
 
 std::string convertLabelToTag(std::string label);
 std::string trimPrefix(const std::string& str, const std::string& prefix);
 std::string getChangelistFromCommit(const git_commit* commit);
-LabelMap getLabelsDetails(P4API* p4, std::string depotPath, std::list<std::string> labels);
+LabelMap getLabelsDetails(P4API* p4, std::string depotPath, std::list<LabelsResult::LabelData> labels);
 
 #endif // LABELS_CONVERSION_H

--- a/p4-fusion/labels_conversion.h
+++ b/p4-fusion/labels_conversion.h
@@ -6,6 +6,7 @@
 std::string convertLabelToTag(std::string label);
 std::string trimPrefix(const std::string& str, const std::string& prefix);
 std::string getChangelistFromCommit(const git_commit* commit);
-LabelMap getLabelsDetails(P4API* p4, std::string depotPath, std::list<LabelsResult::LabelData> labels);
+LabelMap getLabelsDetails(P4API* p4, std::string depotPath, LabelNameToDetails labels);
+LabelNameToDetails getLabelsDetails2(P4API* p4, std::list<LabelsResult::LabelData> labels);
 
 #endif // LABELS_CONVERSION_H

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -58,8 +58,11 @@ int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, c
 		compResp.resultingLabels.insert({ pair.first, pair.second });
 	}
 
-	PRINT("Caching updated labels to " << cachePath)
-	writeLabelMapToDisk(cachePath, compResp.resultingLabels, cachePath);
+	if (cachePath.size() > 0)
+	{
+		PRINT("Caching updated labels to " << cachePath)
+		writeLabelMapToDisk(cachePath, compResp.resultingLabels, cachePath);
+	}
 
 	LabelMap revToLabel = labelDetailsToMap(depotPath, compResp.resultingLabels);
 

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -21,7 +21,6 @@
 
 #define P4_FUSION_VERSION "v1.14.1-sg"
 
-
 // We need to figure out which labels to delete as well?
 // Okay, split it into two functions. Don't be stupid.
 // Or make a struct, babyyyyyy
@@ -62,7 +61,7 @@ int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, c
 	PRINT("Caching updated labels to " << cachePath)
 	writeLabelMapToDisk(cachePath, compResp.resultingLabels, cachePath);
 
-	LabelMap revToLabel = getLabelsDetails(&p4, depotPath, compResp.resultingLabels);
+	LabelMap revToLabel = labelDetailsToMap(depotPath, compResp.resultingLabels);
 
 	PRINT("Updating tags.")
 	git.CreateTagsFromLabels(revToLabel);

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -50,7 +50,7 @@ int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, c
 	compareResponse compResp = compareLabelsToCache(labels, cachedLabels);
 
 	PRINT("Fetching " << compResp.labelsToFetch.size() << " new label details")
-	LabelNameToDetails fetchedLabelMap = getLabelsDetails2(&p4, compResp.labelsToFetch);
+	LabelNameToDetails fetchedLabelMap = getLabelsDetails(&p4, compResp.labelsToFetch);
 
 	// Join the new map with the old map
 	for (const auto& pair : fetchedLabelMap)

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -19,7 +19,7 @@
 #include "labels_conversion.h"
 #include "labels_cache.h"
 
-#define P4_FUSION_VERSION "v1.14.1-sg"
+#define P4_FUSION_VERSION "v1.14.2-sg"
 
 int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, const std::string& cachePath)
 {

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -38,15 +38,15 @@ int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, c
 	if (cachePath.size() > 0)
 	{
 		PRINT("Reading labels from cache")
-		cachedLabels = readLabelMapFromDisk(cachePath);
+		cachedLabels = read_label_map_from_disk(cachePath);
 		SUCCESS("Successfully read " << cachedLabels.size() << " cached labels")
 	}
 
 	PRINT("Comparing cached labels with labels from the Perforce server")
-	compareResponse compResp = compareLabelsToCache(labels, cachedLabels);
+	CompareResponse compResp = compare_labels_to_cache(labels, cachedLabels);
 
 	PRINT("Fetching " << compResp.labelsToFetch.size() << " new label details")
-	LabelNameToDetails fetchedLabelMap = getLabelsDetails(&p4, compResp.labelsToFetch);
+	LabelNameToDetails fetchedLabelMap = get_labels_details(&p4, compResp.labelsToFetch);
 
 	// Join the new map with the old map
 	for (const auto& pair : fetchedLabelMap)
@@ -57,10 +57,10 @@ int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, c
 	if (cachePath.size() > 0)
 	{
 		PRINT("Caching updated labels to " << cachePath)
-		writeLabelMapToDisk(cachePath, compResp.resultingLabels, cachePath);
+		write_label_map_to_disk(cachePath, compResp.resultingLabels, cachePath);
 	}
 
-	LabelMap revToLabel = labelDetailsToMap(depotPath, compResp.resultingLabels);
+	LabelMap revToLabel = label_details_to_map(depotPath, compResp.resultingLabels);
 
 	PRINT("Updating tags.")
 	git.CreateTagsFromLabels(revToLabel);

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 #include <atomic>
-#include <fstream>
 #include <string>
 #include <unordered_map>
 
@@ -18,153 +17,10 @@
 #include "branch_set.h"
 #include "tracer.h"
 #include "labels_conversion.h"
+#include "labels_cache.h"
 
 #define P4_FUSION_VERSION "v1.14.1-sg"
 
-void writeString(std::ofstream& outFile, const std::string& str)
-{
-	size_t length = str.size();
-	outFile.write(reinterpret_cast<const char*>(&length), sizeof(length));
-	outFile.write(str.data(), length);
-}
-
-void writeVectorOfStrings(std::ofstream& outFile, const std::vector<std::string>& vec)
-{
-	size_t vecSize = vec.size();
-	outFile.write(reinterpret_cast<const char*>(&vecSize), sizeof(vecSize));
-	for (const auto& str : vec)
-	{
-		writeString(outFile, str);
-	}
-}
-
-void writeStructToDisk(std::ofstream& outFile, const LabelResult& labels)
-{
-	writeString(outFile, labels.label);
-	writeString(outFile, labels.revision);
-	writeString(outFile, labels.description);
-	writeString(outFile, labels.update);
-	writeVectorOfStrings(outFile, labels.views);
-}
-
-void writeLabelMapToDisk(const std::string& filename, const LabelNameToDetails& labelMap, const std::string& cacheFile)
-{
-	std::ofstream outFile(filename, std::ios::binary);
-	if (!outFile)
-	{
-		ERR("Error opening " << cacheFile << " file for writing, could not cache labels!");
-		return;
-	}
-
-	// Write the size of the map
-	size_t size = labelMap.size();
-	outFile.write(reinterpret_cast<const char*>(&size), sizeof(size));
-
-	// Write each key-value pair
-	for (const auto& pair : labelMap)
-	{
-		writeStructToDisk(outFile, pair.second);
-	}
-
-	outFile.close();
-}
-
-std::string readString(std::ifstream& inFile)
-{
-	size_t length;
-	inFile.read(reinterpret_cast<char*>(&length), sizeof(length));
-	std::string str(length, '\0');
-	inFile.read(&str[0], length);
-	return str;
-}
-
-std::vector<std::string> readVectorOfStrings(std::ifstream& inFile)
-{
-	size_t vecSize;
-	inFile.read(reinterpret_cast<char*>(&vecSize), sizeof(vecSize));
-	std::vector<std::string> vec(vecSize);
-	for (size_t i = 0; i < vecSize; ++i)
-	{
-		vec[i] = readString(inFile);
-	}
-	return vec;
-}
-
-LabelResult readStructFromDisk(std::ifstream& inFile)
-{
-	LabelResult label;
-	label.label = readString(inFile);
-	label.revision = readString(inFile);
-	label.description = readString(inFile);
-	label.update = readString(inFile);
-	label.views = readVectorOfStrings(inFile);
-	return label;
-}
-
-LabelNameToDetails readLabelMapFromDisk(const std::string& filename)
-{
-	LabelNameToDetails labelMap;
-	std::ifstream inFile(filename, std::ios::binary);
-	if (!inFile)
-	{
-		ERR("No label cache found at " << filename)
-		return labelMap;
-	}
-
-	// Read the size of the map
-	size_t size;
-	inFile.read(reinterpret_cast<char*>(&size), sizeof(size));
-
-	// Read each key-value pair and insert into the map
-	for (size_t i = 0; i < size; ++i)
-	{
-		LabelResult value = readStructFromDisk(inFile);
-		labelMap.insert({ value.label, value });
-	}
-
-	inFile.close();
-	return labelMap;
-}
-
-struct compareResponse
-{
-	std::list<LabelsResult::LabelData> labelsToFetch;
-	LabelNameToDetails resultingLabels; // labelMap with the labels that no longer exit removed
-};
-
-// Compares the last updated date in the labels list to the updated dates
-// in the cache, and returns all labels of which the last updated date is
-// different.
-compareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap)
-{
-	LabelNameToDetails newLabelMap;
-	std::list<LabelsResult::LabelData> labelsToFetch;
-	for (const auto& label : labels)
-	{
-		if (labelMap.contains(label.label))
-		{
-			LabelResult cachedLabel
-			    = labelMap.at(label.label);
-			if (cachedLabel.update != label.update)
-			{
-				labelsToFetch.push_back(label);
-			}
-			else
-			{
-				newLabelMap.insert({ label.label, cachedLabel });
-			}
-		}
-		else
-		{
-			labelsToFetch.push_back(label);
-		}
-	}
-
-	return compareResponse {
-		.labelsToFetch = labelsToFetch,
-		.resultingLabels = newLabelMap
-	};
-}
 
 // We need to figure out which labels to delete as well?
 // Okay, split it into two functions. Don't be stupid.

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -21,10 +21,6 @@
 
 #define P4_FUSION_VERSION "v1.14.1-sg"
 
-// We need to figure out which labels to delete as well?
-// Okay, split it into two functions. Don't be stupid.
-// Or make a struct, babyyyyyy
-
 int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, const std::string& cachePath)
 {
 	// Load labels

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 #include <atomic>
+#include <fstream>
+#include <string>
 #include <unordered_map>
 
 #include "utils/timer.h"
@@ -19,7 +21,156 @@
 
 #define P4_FUSION_VERSION "v1.14.1-sg"
 
-int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath)
+void writeString(std::ofstream& outFile, const std::string& str)
+{
+	size_t length = str.size();
+	outFile.write(reinterpret_cast<const char*>(&length), sizeof(length));
+	outFile.write(str.data(), length);
+}
+
+void writeVectorOfStrings(std::ofstream& outFile, const std::vector<std::string>& vec)
+{
+	size_t vecSize = vec.size();
+	outFile.write(reinterpret_cast<const char*>(&vecSize), sizeof(vecSize));
+	for (const auto& str : vec)
+	{
+		writeString(outFile, str);
+	}
+}
+
+void writeStructToDisk(std::ofstream& outFile, const LabelResult& labels)
+{
+	writeString(outFile, labels.label);
+	writeString(outFile, labels.revision);
+	writeString(outFile, labels.description);
+	writeString(outFile, labels.update);
+	writeVectorOfStrings(outFile, labels.views);
+}
+
+void writeLabelMapToDisk(const std::string& filename, const LabelNameToDetails& labelMap, const std::string& cacheFile)
+{
+	std::ofstream outFile(filename, std::ios::binary);
+	if (!outFile)
+	{
+		ERR("Error opening " << cacheFile << " file for writing, could not cache labels!");
+		return;
+	}
+
+	// Write the size of the map
+	size_t size = labelMap.size();
+	outFile.write(reinterpret_cast<const char*>(&size), sizeof(size));
+
+	// Write each key-value pair
+	for (const auto& pair : labelMap)
+	{
+		writeStructToDisk(outFile, pair.second);
+	}
+
+	outFile.close();
+}
+
+std::string readString(std::ifstream& inFile)
+{
+	size_t length;
+	inFile.read(reinterpret_cast<char*>(&length), sizeof(length));
+	std::string str(length, '\0');
+	inFile.read(&str[0], length);
+	return str;
+}
+
+std::vector<std::string> readVectorOfStrings(std::ifstream& inFile)
+{
+	size_t vecSize;
+	inFile.read(reinterpret_cast<char*>(&vecSize), sizeof(vecSize));
+	std::vector<std::string> vec(vecSize);
+	for (size_t i = 0; i < vecSize; ++i)
+	{
+		vec[i] = readString(inFile);
+	}
+	return vec;
+}
+
+LabelResult readStructFromDisk(std::ifstream& inFile)
+{
+	LabelResult label;
+	label.label = readString(inFile);
+	label.revision = readString(inFile);
+	label.description = readString(inFile);
+	label.update = readString(inFile);
+	label.views = readVectorOfStrings(inFile);
+	return label;
+}
+
+LabelNameToDetails readLabelMapFromDisk(const std::string& filename)
+{
+	LabelNameToDetails labelMap;
+	std::ifstream inFile(filename, std::ios::binary);
+	if (!inFile)
+	{
+		ERR("No label cache found at " << filename)
+		return labelMap;
+	}
+
+	// Read the size of the map
+	size_t size;
+	inFile.read(reinterpret_cast<char*>(&size), sizeof(size));
+
+	// Read each key-value pair and insert into the map
+	for (size_t i = 0; i < size; ++i)
+	{
+		LabelResult value = readStructFromDisk(inFile);
+		labelMap.insert({ value.label, value });
+	}
+
+	inFile.close();
+	return labelMap;
+}
+
+struct compareResponse
+{
+	std::list<LabelsResult::LabelData> labelsToFetch;
+	LabelNameToDetails resultingLabels; // labelMap with the labels that no longer exit removed
+};
+
+// Compares the last updated date in the labels list to the updated dates
+// in the cache, and returns all labels of which the last updated date is
+// different.
+compareResponse compareLabelsToCache(const std::list<LabelsResult::LabelData>& labels, LabelNameToDetails& labelMap)
+{
+	LabelNameToDetails newLabelMap;
+	std::list<LabelsResult::LabelData> labelsToFetch;
+	for (const auto& label : labels)
+	{
+		if (labelMap.contains(label.label))
+		{
+			LabelResult cachedLabel
+			    = labelMap.at(label.label);
+			if (cachedLabel.update != label.update)
+			{
+				labelsToFetch.push_back(label);
+			}
+			else
+			{
+				newLabelMap.insert({ label.label, cachedLabel });
+			}
+		}
+		else
+		{
+			labelsToFetch.push_back(label);
+		}
+	}
+
+	return compareResponse {
+		.labelsToFetch = labelsToFetch,
+		.resultingLabels = newLabelMap
+	};
+}
+
+// We need to figure out which labels to delete as well?
+// Okay, split it into two functions. Don't be stupid.
+// Or make a struct, babyyyyyy
+
+int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath, const std::string& cachePath)
 {
 	// Load labels
 	PRINT("Requesting labels from the Perforce server")
@@ -32,9 +183,32 @@ int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath)
 	const std::list<LabelsResult::LabelData>& labels = labelsRes.GetLabels();
 	SUCCESS("Received " << labels.size() << " labels from the Perforce server")
 
-	LabelMap revToLabel = getLabelsDetails(&p4, depotPath, labels);
+	LabelNameToDetails cachedLabels;
+	if (cachePath.size() > 0)
+	{
+		PRINT("Reading labels from cache")
+		cachedLabels = readLabelMapFromDisk(cachePath);
+		SUCCESS("Successfully read " << cachedLabels.size() << " cached labels")
+	}
 
-	SUCCESS("Updating tags.")
+	PRINT("Comparing cached labels with labels from the Perforce server")
+	compareResponse compResp = compareLabelsToCache(labels, cachedLabels);
+
+	PRINT("Fetching " << compResp.labelsToFetch.size() << " new label details")
+	LabelNameToDetails fetchedLabelMap = getLabelsDetails2(&p4, compResp.labelsToFetch);
+
+	// Join the new map with the old map
+	for (const auto& pair : fetchedLabelMap)
+	{
+		compResp.resultingLabels.insert({ pair.first, pair.second });
+	}
+
+	PRINT("Caching updated labels to " << cachePath)
+	writeLabelMapToDisk(cachePath, compResp.resultingLabels, cachePath);
+
+	LabelMap revToLabel = getLabelsDetails(&p4, depotPath, compResp.resultingLabels);
+
+	PRINT("Updating tags.")
 	git.CreateTagsFromLabels(revToLabel);
 	return 0;
 }
@@ -175,7 +349,7 @@ int Main(int argc, char** argv)
 
 		if (!arguments.GetNoConvertLabels())
 		{
-			return fetchAndUpdateLabels(p4, git, depotPath);
+			return fetchAndUpdateLabels(p4, git, depotPath, arguments.GetLabelCache());
 		}
 
 		return 0;
@@ -327,7 +501,7 @@ int Main(int argc, char** argv)
 	if (!arguments.GetNoConvertLabels())
 	{
 		P4API p4labelsClient;
-		return fetchAndUpdateLabels(p4labelsClient, git, depotPath);
+		return fetchAndUpdateLabels(p4labelsClient, git, depotPath, arguments.GetLabelCache());
 	}
 
 	return 0;

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -4,12 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-#include <thread>
 #include <atomic>
 #include <unordered_map>
-#include <typeinfo>
-
-#include "common.h"
 
 #include "utils/timer.h"
 #include "utils/arguments.h"
@@ -19,7 +15,6 @@
 #include "git_api.h"
 #include "branch_set.h"
 #include "tracer.h"
-#include "git2/commit.h"
 #include "labels_conversion.h"
 
 #define P4_FUSION_VERSION "v1.14.1-sg"
@@ -34,7 +29,7 @@ int fetchAndUpdateLabels(P4API& p4, GitAPI& git, const std::string& depotPath)
 		ERR("Failed to retrieve labels for mapping: " << labelsRes.PrintError())
 		return 1;
 	}
-	const std::list<std::string>& labels = labelsRes.GetLabels();
+	const std::list<LabelsResult::LabelData>& labels = labelsRes.GetLabels();
 	SUCCESS("Received " << labels.size() << " labels from the Perforce server")
 
 	LabelMap revToLabel = getLabelsDetails(&p4, depotPath, labels);

--- a/p4-fusion/p4_api.cc
+++ b/p4-fusion/p4_api.cc
@@ -244,6 +244,8 @@ LabelsResult P4API::Labels()
 {
 	MTR_SCOPE("P4", __func__);
 
+	// -a - return all labels
+	// -t - add last updated at timestamp to labels
 	return Run<LabelsResult>("labels", { "-a", "-t" }, []() -> LabelsResult
 	    { return {}; });
 }

--- a/p4-fusion/p4_api.cc
+++ b/p4-fusion/p4_api.cc
@@ -244,7 +244,7 @@ LabelsResult P4API::Labels()
 {
 	MTR_SCOPE("P4", __func__);
 
-	return Run<LabelsResult>("labels", { "-a" }, []() -> LabelsResult
+	return Run<LabelsResult>("labels", { "-a", "-t" }, []() -> LabelsResult
 	    { return {}; });
 }
 

--- a/p4-fusion/utils/arguments.cc
+++ b/p4-fusion/utils/arguments.cc
@@ -30,6 +30,7 @@ Arguments::Arguments(int argc, char** argv)
 	OptionalParameter("--flushRate", "30", "Interval in seconds at which the profiling data is flushed to the disk.");
 	OptionalParameter("--noColor", "false", "Disable colored output.");
 	OptionalParameter("--noConvertLabels", "false", "Whether or not to disable label to tag conversion.");
+	OptionalParameter("--labelCache", "", "Absolute path to a label cache file. If not specified, labels will not be cached.");
 
 	for (int i = 1; i < argc - 1; i += 2)
 	{

--- a/p4-fusion/utils/arguments.h
+++ b/p4-fusion/utils/arguments.h
@@ -58,5 +58,6 @@ public:
 	[[nodiscard]] bool GetNoMerge() const { return GetParameterBool("--noMerge"); };
 	[[nodiscard]] bool GetNoBaseCommit() const { return GetParameterBool("--noBaseCommit"); };
 	[[nodiscard]] bool GetNoConvertLabels() const { return GetParameterBool("--noConvertLabels"); };
+	[[nodiscard]] std::string GetLabelCache() const { return GetParameter("--labelCache"); };
 	[[nodiscard]] std::vector<std::string> GetBranches() const { return GetParameterList("--branch"); };
 };


### PR DESCRIPTION
Adds a `--labelCache` option that takes an absolute path to a file to use as a label cache.

Labels are cached by just writing the binary data directly to a file.

We use the unix timestamp from the `p4 labels` command, as opposed to the data returned by `p4 label <labelname>`, which is a more complex date format.

When updating labels, the cache is read, and the `update` timestamp is compared to the timestamp of the newly fetched label list. All labels that changed (or are new) are fetched from the server. Labels that are missing now are removed and deleted from the repo.

## Test plan

Manual tests.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
