### PR TITLE
Decode special characters in Perforce paths

### DIFF
--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -75,7 +75,7 @@ void FileData::SetPendingDownload()
 
 void FileData::SetRelativePath(std::string& relativePath)
 {
-	m_data->relativePath = relativePath;
+	m_data->relativePath = decodePath(relativePath);
 }
 
 void FileDataStore::SetAction(std::string fileAction)

--- a/p4-fusion/commands/file_data.h
+++ b/p4-fusion/commands/file_data.h
@@ -91,7 +91,7 @@ public:
 
 	[[nodiscard]] const std::string& GetDepotFile() const { return m_data->depotFile; };
 	[[nodiscard]] const std::string& GetRevision() const { return m_data->revision; };
-	[[nodiscard]] std::string GetRelativePath() const { return decodePath(m_data->relativePath); };
+	[[nodiscard]] const std::string& GetRelativePath() const { return m_data->relativePath; };
 	[[nodiscard]] const std::string& GetBlobOID() const
 	{
 		std::lock_guard<std::mutex> lock(m_data->blobOIDMu);

--- a/p4-fusion/commands/file_data.h
+++ b/p4-fusion/commands/file_data.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <atomic>
+#include "utils/p4_helpers.h"
 #include "common.h"
 #include "utils/std_helpers.h"
 
@@ -90,7 +91,7 @@ public:
 
 	[[nodiscard]] const std::string& GetDepotFile() const { return m_data->depotFile; };
 	[[nodiscard]] const std::string& GetRevision() const { return m_data->revision; };
-	[[nodiscard]] const std::string& GetRelativePath() const { return m_data->relativePath; };
+	[[nodiscard]] std::string GetRelativePath() const { return decodePath(m_data->relativePath); };
 	[[nodiscard]] const std::string& GetBlobOID() const
 	{
 		std::lock_guard<std::mutex> lock(m_data->blobOIDMu);

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -12,6 +12,7 @@
 #include "minitrace.h"
 #include "labels_conversion.h"
 #include "utils/std_helpers.h"
+#include "utils/p4_helpers.h"
 
 void checkGit2Error(int errcode)
 {
@@ -322,15 +323,16 @@ std::string GitAPI::WriteChangelistBranch(
 
 	for (auto& file : files)
 	{
+		auto relativePath = decodePath(file.GetRelativePath());
 		if (file.IsDeleted())
 		{
-			checkGit2Error(git_index_remove_bypath(idx, file.GetRelativePath().c_str()));
+			checkGit2Error(git_index_remove_bypath(idx, relativePath.c_str()));
 		}
 		else
 		{
 			git_index_entry entry = {
 				.mode = GIT_FILEMODE_BLOB,
-				.path = file.GetRelativePath().c_str(),
+				.path = relativePath.c_str(),
 			};
 
 			auto& blobOID = file.GetBlobOID();

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -12,7 +12,6 @@
 #include "minitrace.h"
 #include "labels_conversion.h"
 #include "utils/std_helpers.h"
-#include "utils/p4_helpers.h"
 
 void checkGit2Error(int errcode)
 {
@@ -323,7 +322,7 @@ std::string GitAPI::WriteChangelistBranch(
 
 	for (auto& file : files)
 	{
-		auto relativePath = decodePath(file.GetRelativePath());
+		auto relativePath = file.GetRelativePath();
 		if (file.IsDeleted())
 		{
 			checkGit2Error(git_index_remove_bypath(idx, relativePath.c_str()));

--- a/p4-fusion/utils/p4_helpers.cc
+++ b/p4-fusion/utils/p4_helpers.cc
@@ -6,7 +6,6 @@
 // '#' -> "%23"
 // '*' -> "%2A"
 // '%' -> "%25"
-// ':' -> "%3A"
 std::string decodePath(std::string input)
 {
 	std::string result;
@@ -31,10 +30,6 @@ std::string decodePath(std::string input)
 			else if (hexValue == "%25")
 			{
 				result += '%';
-			}
-			else if (hexValue == "%3A")
-			{
-				result += ':';
 			}
 			else
 			{

--- a/p4-fusion/utils/p4_helpers.cc
+++ b/p4-fusion/utils/p4_helpers.cc
@@ -6,7 +6,7 @@
 // '#' -> "%23"
 // '*' -> "%2A"
 // '%' -> "%25"
-std::string decodePath(std::string input)
+std::string decodePath(const std::string& input)
 {
 	std::string result;
 	for (size_t i = 0; i < input.size(); i++)

--- a/p4-fusion/utils/p4_helpers.cc
+++ b/p4-fusion/utils/p4_helpers.cc
@@ -1,0 +1,55 @@
+#include "p4_helpers.h"
+
+// Decodes paths from Perforce that may be encoded.
+// Perforce encodes the following characters:
+// '@' -> "%40"
+// '#' -> "%23"
+// '*' -> "%2A"
+// '%' -> "%25"
+// ':' -> "%3A"
+std::string decodePath(std::string input)
+{
+	std::string result;
+	for (size_t i = 0; i < input.size(); i++)
+	{
+		if (input[i] == '%' && i + 2 < input.size())
+		{
+			std::string hexValue = input.substr(i, 3);
+
+			if (hexValue == "%40")
+			{
+				result += '@';
+			}
+			else if (hexValue == "%23")
+			{
+				result += '#';
+			}
+			else if (hexValue == "%2A")
+			{
+				result += '*';
+			}
+			else if (hexValue == "%25")
+			{
+				result += '%';
+			}
+			else if (hexValue == "%3A")
+			{
+				result += ':';
+			}
+			else
+			{
+				// If it's none of the above we just keep it as is, as these are
+				// the only characters Perforce would have replaced.
+				result += hexValue;
+			}
+
+			i += 2;
+		}
+		else
+		{
+			result += input[i];
+		}
+	}
+
+	return result;
+}

--- a/p4-fusion/utils/p4_helpers.h
+++ b/p4-fusion/utils/p4_helpers.h
@@ -1,0 +1,3 @@
+#include <string>
+
+std::string decodePath(std::string input);

--- a/p4-fusion/utils/p4_helpers.h
+++ b/p4-fusion/utils/p4_helpers.h
@@ -1,3 +1,3 @@
 #include <string>
 
-std::string decodePath(std::string input);
+std::string decodePath(const std::string& input);


### PR DESCRIPTION
Perforce encodes certain characters when adding them to a depot: https://www.perforce.com/manuals/p4guide/Content/P4Guide/syntax.syntax.restrictions.html

And it decodes them again when syncing the depot. `p4-fusion` does not do the decoding when converting to a repository, which leads to files having the wrong names on Sourcegraph (e.g. `my@file.txt` would be `my%40file.txt` on Sourcegraph).

This PR adds a function to decode the file path when converting the depot to a git repository.

## Test plan

Tested using a depot with encoded file paths.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
